### PR TITLE
refac: add metadata collecetion to vector store

### DIFF
--- a/paperchat/core/rag_pipeline.py
+++ b/paperchat/core/rag_pipeline.py
@@ -41,14 +41,13 @@ class RAGPipeline:
         Returns:
             A list of retrieved document chunk dictionaries with metadata.
         """
-        # returns a Milvus ExtraList where the actual list[dict] is the first element
-        results = self.vector_store.retrieve(
+        results = self.vector_store.search(
             query_text=query,
             top_k=top_k,
             threshold=threshold,
             filter_expression=filter_expression,
         )
-        return results[0]
+        return results
 
     def generate(
         self, query: str, retrieved_results: list[dict[str, Any]], stream: bool = False

--- a/paperchat/core/vector_store.py
+++ b/paperchat/core/vector_store.py
@@ -4,6 +4,7 @@ This module provides a unified interface for storing and retrieving
 document chunks and their embeddings using Milvus as the backend.
 """
 
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -31,38 +32,275 @@ class VectorStore:
     Attributes:
         db_path (str): Path to the Milvus Lite database file.
         collection_name (str): Name of the collection managed by this instance.
+        metadata_collection_name (str): Name of the metadata collection.
         embedding_dim (int): Dimension of the vectors stored.
         client (MilvusClient): The initialized Milvus client.
-        schema (CollectionSchema): The schema used for the collection.
+        main_schema (CollectionSchema): The schema used for the main collection.
+        metadata_schema (CollectionSchema): The schema used for the metadata collection.
     """
 
     DEFAULT_COLLECTION_NAME = "paperchat_docs"
+    METADATA_COLLECTION_NAME = "paperchat_metadata"
     VECTOR_DB_DIR = str(Path.home() / ".paperchat" / "paperchat.db")
 
-    def __init__(self):
+    def __init__(self, db_path: str = VECTOR_DB_DIR):
         """
-        Initializes the MilvusVectorStore, connects to Milvus, and ensures
-        the specified collection and index exist.
-
+        Initializes the VectorStore, connects to Milvus, and ensures
+        both the main document and metadata collections and their indices exist.
         """
-        self.db_path = self.VECTOR_DB_DIR
+        self.db_path = db_path
         self.collection_name = self.DEFAULT_COLLECTION_NAME
+        self.metadata_collection_name = self.METADATA_COLLECTION_NAME
         # TODO: allow passing in different embedding functions
         self._embed_fn = model.DefaultEmbeddingFunction()
         self.embedding_dim = getattr(self._embed_fn, "dim", 768)
-        self.logger = get_component_logger(f"MilvusVectorStore[{self.collection_name}]")
+        self.logger = get_component_logger("VectorStore")
+
         try:
             self.client = MilvusClient(uri=self.db_path)
+            self.logger.info(f"Connected to Milvus: {self.db_path}")
         except Exception as e:
             self.logger.exception(f"Failed to initialize MilvusClient: {e}")
             raise
 
-        self.schema = self._define_schema()
-        self.get_or_create_collection()
-        self.build_index()
+        self.main_schema = self._define_main_schema()
+        self.metadata_schema = self._define_metadata_schema()
+        self._get_or_create_collection(self.collection_name, self.main_schema)
+        self._get_or_create_collection(self.metadata_collection_name, self.metadata_schema)
+        self._build_indices()
 
-    def _define_schema(self) -> CollectionSchema:
-        """Defines the Milvus collection schema."""
+    def add_document(self, pdf_path: str | Path, max_tokens: int = 1024) -> bool:
+        """
+        Processes a PDF document, adds chunks to the main collection,
+        and adds metadata to the metadata collection. Skips if the document
+        (based on source) already exists in the metadata collection.
+
+        Args:
+            pdf_path: Path to the PDF file.
+            max_tokens: Maximum number of tokens per chunk.
+
+        Returns:
+            True if the document was successfully processed and added (or already existed),
+            False if an error occurred during processing or insertion.
+        """
+        pdf_file = Path(pdf_path)
+        source_id = pdf_file.stem
+        self.logger.info(f"Processing request for document: {pdf_file.name} (ID: {source_id})")
+
+        try:
+            # 1. check metadata existence
+            existing = self.client.query(
+                collection_name=self.metadata_collection_name,
+                filter=f'source == "{source_id}"',
+                output_fields=["source"],
+                limit=1,
+            )
+
+            if existing:
+                self.logger.info(f"Document ID '{source_id}' already exists in metadata. Skipping.")
+                return True
+
+            # 2. process pdf into chunks (if new)
+            self.logger.info(f"Document ID '{source_id}' not found. Processing PDF...")
+            pdf_data = process_pdf_document(
+                pdf_path, embed_fn=self._embed_fn, max_tokens_per_chunk=max_tokens
+            )
+
+            for chunk in pdf_data:
+                chunk["source"] = source_id
+
+            # 3. insert chunks into main collection
+            self.logger.info(f"Inserting {len(pdf_data)} chunks into '{self.collection_name}'")
+            chunk_result = self.client.insert(collection_name=self.collection_name, data=pdf_data)
+            insert_count = chunk_result.get("insert_count", 0)
+            if insert_count != len(pdf_data):
+                self.logger.error(
+                    f"Mismatch in chunk insertion count for {source_id}. Expected {len(pdf_data)}, got {insert_count}. IDs: {chunk_result.get('primary_keys')}"
+                )
+                # Decide on rollback or error state? For now, log error and continue to metadata attempt, but return False later.
+                # Consider deleting inserted chunks if possible? client.delete might be complex with specific IDs.
+                return False
+
+            self.logger.info(f"Successfully inserted {insert_count} chunks for {source_id}")
+
+            # 4. insert metadata entry
+            iso_timestamp = datetime.now().isoformat()
+            metadata_entry = [
+                {
+                    "source": source_id,
+                    "original_filename": pdf_file.name,
+                    "date_added": iso_timestamp,
+                }
+            ]
+            self.logger.info(
+                f"Inserting metadata for '{source_id}' into '{self.metadata_collection_name}'"
+            )
+            meta_result = self.client.insert(
+                collection_name=self.metadata_collection_name, data=metadata_entry
+            )
+            meta_insert_count = meta_result.get("insert_count", 0)
+
+            if meta_insert_count != 1:
+                self.logger.error(
+                    f"Failed to insert metadata for {source_id}. Result: {meta_result}"
+                )
+                return False
+
+            self.logger.info(f"Successfully added document '{source_id}'")
+            return True
+
+        except Exception as e:
+            self.logger.exception(f"Failed processing/adding document {source_id}: {e}")
+            return False
+
+    def retrieve(
+        self,
+        query_text: str,
+        top_k: int = DEFAULT_SIMILARITY_TOP_K,
+        threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+        output_fields: list[str] | None = None,
+        filter_expression: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Searches the main collection for text chunks similar to the query text.
+
+        Args:
+            query_text: The text to search for.
+            top_k: The maximum number of results to return.
+            threshold: The minimum similarity score to return.
+            output_fields: List of field names to include in the results.
+                           Defaults to main schema fields except embedding.
+            filter_expression: Milvus filter expression string (e.g., "source == 'doc1.pdf'").
+
+        Returns:
+            Raw search results from Milvus.
+        """
+        if output_fields is None:
+            # default: all schema fields except embedding
+            output_fields = [f.name for f in self.main_schema.fields if f.name != "embedding"]
+
+        try:
+            self.logger.debug(f"Loading collection '{self.collection_name}' for search.")
+            query_embedding = self._embed_fn.encode_queries([query_text])[0]
+        except Exception as e:
+            self.logger.exception(f"Failed to generate query embedding or load collection: {e}")
+            return []
+
+        search_params = {
+            "nprobe": 10,
+            "metric_type": "COSINE",
+            "radius": threshold,
+            "range_filter": 1.0,
+        }
+
+        try:
+            results = self.client.search(
+                collection_name=self.collection_name,
+                data=[query_embedding],
+                search_params=search_params,
+                limit=top_k,
+                output_fields=output_fields,
+                filter=filter_expression,
+            )
+        except Exception as e:
+            self.logger.exception(f"Search failed: {e}")
+            results = []
+
+        return results
+
+    def list_documents(self) -> list[dict[str, Any]]:
+        """
+        Lists all documents by querying the metadata collection.
+
+        Returns:
+            A list of dictionaries, each containing metadata for one document
+            (source, original_filename, date_added).
+            Returns an empty list if there are no documents or an error occurs.
+        """
+        self.logger.debug(f"Listing documents from '{self.metadata_collection_name}'")
+        try:
+            results = self.client.query(
+                collection_name=self.metadata_collection_name,
+                output_fields=["source", "original_filename", "date_added"],
+                limit=100,
+            )
+            self.logger.info(f"Found {len(results)} documents in metadata.")
+            return results
+        except Exception as e:
+            self.logger.exception(f"Failed to list documents from metadata: {e}")
+            return []
+
+    def remove_document(self, source_id: str) -> tuple[int, int]:
+        """
+        Removes a document and its associated data from both the metadata
+        and main document collections based on the source identifier.
+
+        Args:
+            source_id: The unique identifier (e.g., file stem) of the document to delete.
+
+        Returns:
+            A tuple containing:
+            (number of metadata entries deleted, number of chunks deleted).
+            Typically (1, N) on success, (0, 0) if not found, or potentially
+            (0, N) or (1, 0) if deletion from one collection fails.
+        """
+        self.logger.info(f"Attempting to remove document with ID: '{source_id}'")
+        metadata_deleted_count = 0
+        chunks_deleted_count = 0
+
+        # step 1: remove from metadata
+        try:
+            self.logger.debug(
+                f"Removing metadata entry for '{source_id}' from '{self.metadata_collection_name}'"
+            )
+            meta_del_result = self.client.delete(
+                collection_name=self.metadata_collection_name,
+                filter=f'source == "{source_id}"',
+            )
+            if hasattr(meta_del_result, "delete_count"):
+                metadata_deleted_count = meta_del_result.delete_count
+            elif hasattr(meta_del_result, "primary_keys"):
+                metadata_deleted_count = len(meta_del_result.primary_keys)
+            else:
+                metadata_deleted_count = 1 if meta_del_result else 0
+
+            self.logger.info(
+                f"Removed {metadata_deleted_count} entries from metadata for '{source_id}'"
+            )
+        except Exception as e:
+            self.logger.exception(
+                f"Failed to remove from metadata collection for '{source_id}': {e}"
+            )
+
+        # step 2: remove from main collection
+        try:
+            self.logger.debug(f"Removing chunks for '{source_id}' from '{self.collection_name}'")
+            chunk_del_result = self.client.delete(
+                collection_name=self.collection_name,
+                filter=f'source == "{source_id}"',
+            )
+            if hasattr(chunk_del_result, "delete_count"):
+                chunks_deleted_count = chunk_del_result.delete_count
+            elif hasattr(chunk_del_result, "primary_keys"):
+                chunks_deleted_count = len(chunk_del_result.primary_keys)
+            else:
+                chunks_deleted_count = 0
+
+            self.logger.info(
+                f"Removed {chunks_deleted_count} chunks from main collection for '{source_id}'"
+            )
+        except Exception as e:
+            self.logger.exception(
+                f"Failed to remove chunks from main collection for '{source_id}': {e}"
+            )
+
+        self.logger.info(
+            f"Removal complete for '{source_id}'. Metadata removed: {metadata_deleted_count}, Chunks removed: {chunks_deleted_count}"
+        )
+        return metadata_deleted_count, chunks_deleted_count
+
+    def _define_main_schema(self) -> CollectionSchema:
+        """Defines the Milvus collection schema for document chunks."""
         fields = [
             FieldSchema(name="pk", dtype=DataType.INT64, is_primary=True, auto_id=True),
             FieldSchema(
@@ -82,31 +320,60 @@ class VectorStore:
                 name="source",
                 dtype=DataType.VARCHAR,
                 max_length=512,
-                description="Source document filename",
+                description="Source document filename stem (e.g., pdf_file.stem)",
             ),
         ]
-
         return CollectionSchema(
             fields, description="Document Chunks Collection", enable_dynamic_field=True
         )
 
-    def get_or_create_collection(self) -> None:
-        """Creates the collection if it doesn't exist."""
-        try:
-            collection_exists = self.client.has_collection(self.collection_name)
-            if not collection_exists:
-                self.logger.info(f"Creating collection '{self.collection_name}'")
-                self.client.create_collection(
-                    collection_name=self.collection_name, schema=self.schema
-                )
+    def _define_metadata_schema(self) -> CollectionSchema:
+        """Defines the Milvus collection schema for document metadata."""
+        fields = [
+            FieldSchema(name="pk", dtype=DataType.INT64, is_primary=True, auto_id=True),
+            FieldSchema(
+                name="source",
+                dtype=DataType.VARCHAR,
+                max_length=512,
+                description="Unique source identifier/filename stem (e.g., pdf_file.stem)",
+            ),
+            FieldSchema(
+                name="original_filename",
+                dtype=DataType.VARCHAR,
+                max_length=1024,
+                description="Original filename of the source document",
+            ),
+            FieldSchema(
+                name="date_added",
+                dtype=DataType.VARCHAR,
+                max_length=64,
+                description="ISO 8601 timestamp when the document was added",
+            ),
+        ]
+        return CollectionSchema(
+            fields, description="Document Metadata Collection", enable_dynamic_field=False
+        )
 
+    def _get_or_create_collection(self, collection_name: str, schema: CollectionSchema) -> None:
+        """Creates the specified collection if it doesn't exist."""
+        try:
+            collection_exists = self.client.has_collection(collection_name)
+            if not collection_exists:
+                self.logger.info(f"Creating collection '{collection_name}'")
+                self.client.create_collection(collection_name=collection_name, schema=schema)
+            else:
+                self.logger.info(f"Collection '{collection_name}' already exists.")
         except Exception as e:
-            self.logger.exception(f"Failed to create collection: {e}")
+            self.logger.exception(f"Failed to check/create collection '{collection_name}': {e}")
             raise
 
-    def build_index(self) -> None:
-        """Creates a vector index on the embedding field."""
+    def _build_indices(self) -> None:
+        """Creates indices for both main and metadata collections if they don't exist."""
+        # vector db index
         try:
+            self.logger.info(
+                f"Ensuring vector index exists on 'embedding' for '{self.collection_name}'"
+            )
             index_params = self.client.prepare_index_params()
             index_params.add_index(
                 field_name="embedding",
@@ -114,118 +381,26 @@ class VectorStore:
                 metric_type="COSINE",
                 params={"nlist": 128},
             )
-
             self.client.create_index(
-                collection_name=self.collection_name,
-                index_params=index_params,
+                collection_name=self.collection_name, index_params=index_params
             )
+            self.logger.info(f"Vector index ensured for '{self.collection_name}'")
         except Exception as e:
-            self.logger.warning(f"Could not create index: {e}")
+            self.logger.warning(f"Could not ensure vector index for '{self.collection_name}': {e}")
 
-    def add_document(self, pdf_path: str | Path, max_tokens: int = 1024) -> bool:
-        """
-        Processes a PDF document, extracts chunks, generates embeddings,
-        and inserts them into the Milvus collection. Automatically skips
-        documents that have already been inserted.
-
-        Args:
-            pdf_path: Path to the PDF file.
-            max_tokens: Maximum number of tokens per chunk
-
-        Returns:
-            True if the document was successfully processed and inserted, False otherwise
-        """
-        pdf_file = Path(pdf_path)
-        self.logger.info(f"Processing: {pdf_file.name}")
-
+        # metadata db index
+        metadata_index_field = "source"
         try:
-            # check if document already exists in the collection
-            existing = self.client.query(
-                collection_name=self.collection_name,
-                filter=f'source == "{pdf_file.stem}"',
-                output_fields=["source"],
-                limit=1,
+            metadata_index_params = self.client.prepare_index_params()
+            metadata_index_params.add_index(field_name=metadata_index_field)
+            self.logger.info(
+                f"Ensuring scalar index exists on '{metadata_index_field}' for '{self.metadata_collection_name}'"
             )
-
-            if existing:
-                self.logger.info(f"Document '{pdf_file.stem}' already exists. Skipping.")
-                return True
-
-            pdf_data = process_pdf_document(
-                pdf_path, embed_fn=self._embed_fn, max_tokens_per_chunk=max_tokens
+            self.client.create_index(
+                collection_name=self.metadata_collection_name, index_params=metadata_index_params
             )
-
-            result = self.client.insert(collection_name=self.collection_name, data=pdf_data)
-            insert_count = result.get("insert_count", 0)
-            self.logger.info(f"Successfully inserted {insert_count} chunks")
-
-            return True
-
+            self.logger.info(f"Scalar index ensured for '{self.metadata_collection_name}'")
         except Exception as e:
-            self.logger.exception(f"Failed to insert data: {e}")
-
-            return False
-
-    def retrieve(
-        self,
-        query_text: str,
-        top_k: int = DEFAULT_SIMILARITY_TOP_K,
-        threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
-        output_fields: list[str] | None = None,
-        filter_expression: str | None = None,  # For metadata filtering later
-    ) -> list[dict[str, Any]]:
-        """
-        Searches the collection for text chunks similar to the query text.
-
-        Args:
-            query_text: The text to search for.
-            top_k: The maximum number of results to return.
-            threshold: The minimum similarity score to return.
-            output_fields: List of field names to include in the results.
-                           Defaults to schema fields plus similarity/distance.
-            filter_expression: Milvus filter expression string (e.g., "source == 'doc1.pdf'").
-
-        Returns:
-            Raw search results from Milvus
-        """
-        if output_fields is None:
-            # default: all schema fields except embedding
-            output_fields = [f.name for f in self.schema.fields if f.name != "embedding"]
-
-        try:
-            self.logger.debug(f"Loading collection '{self.collection_name}' for search.")
-            self.client.load_collection(self.collection_name)
-            query_embedding = self._embed_fn.encode_queries([query_text])[0]
-        except Exception as e:
-            self.logger.exception(f"Failed to generate query embedding or load collection: {e}")
-            return []
-
-        ########################################################################
-        # radius and range_filter are used to filter results by distance
-        # radius is boundary furthest from "ideal"
-        # range_filter is boundary closest to "ideal"
-        # for COSINE: radius <= similarity <= range_filter
-        # for L2: radius >= similarity >= range_filter
-        ########################################################################
-        search_params = {
-            "nprobe": 10,
-            "metric_type": "COSINE",
-            "radius": threshold,
-            "range_filter": 1.0,
-        }
-
-        try:
-            results = self.client.search(
-                collection_name=self.collection_name,
-                data=[query_embedding],
-                search_params=search_params,
-                limit=top_k,
-                output_fields=output_fields,
-                filter=filter_expression,
+            self.logger.warning(
+                f"Could not ensure scalar index for '{self.metadata_collection_name}': {e}"
             )
-
-        except Exception as e:
-            self.logger.exception(f"Search failed: {e}")
-            results = []
-
-        return results

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -52,12 +52,12 @@ def test_retrieve(rag_pipeline, mock_vector_store):
     filter_expression = "source == 'test.pdf'"
 
     mock_inner_results = [{"text": "test result"}]
-    mock_vector_store.retrieve.return_value = [mock_inner_results]
+    mock_vector_store.search.return_value = mock_inner_results
 
     results = rag_pipeline.retrieve(query, top_k, threshold, filter_expression)
 
     assert results == mock_inner_results
-    mock_vector_store.retrieve.assert_called_once_with(
+    mock_vector_store.search.assert_called_once_with(
         query_text=query,
         top_k=top_k,
         threshold=threshold,

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -48,16 +48,20 @@ def test_retrieve(rag_pipeline, mock_vector_store):
     """Test the retrieve method."""
     query = "test query"
     top_k = 3
+    threshold = 0.8
     filter_expression = "source == 'test.pdf'"
 
-    mock_results = [{"text": "test result"}]
-    mock_vector_store.retrieve.return_value = mock_results
+    mock_inner_results = [{"text": "test result"}]
+    mock_vector_store.retrieve.return_value = [mock_inner_results]
 
-    results = rag_pipeline.retrieve(query, top_k, filter_expression)
+    results = rag_pipeline.retrieve(query, top_k, threshold, filter_expression)
 
-    assert results == mock_results
+    assert results == mock_inner_results
     mock_vector_store.retrieve.assert_called_once_with(
-        query_text=query, top_k=top_k, filter_expression=filter_expression
+        query_text=query,
+        top_k=top_k,
+        threshold=threshold,
+        filter_expression=filter_expression,
     )
 
 

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,6 +1,7 @@
 """Tests for the vector store module."""
 
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from unittest import mock
 
@@ -8,7 +9,19 @@ import numpy as np
 import pytest
 from pymilvus import CollectionSchema
 
-from paperchat.core.vector_store import VectorStore
+from paperchat.core.vector_store import DEFAULT_SIMILARITY_TOP_K, VectorStore
+
+MAIN_FIELD_NAMES = {
+    "pk",
+    "chunk_id",
+    "embedding",
+    "text",
+    "label",
+    "page_numbers",
+    "headings",
+    "source",
+}
+METADATA_FIELD_NAMES = {"pk", "source", "original_filename", "date_added"}
 
 
 @pytest.fixture
@@ -23,142 +36,440 @@ def mock_milvus_client():
     """Create a mock MilvusClient."""
     with mock.patch("paperchat.core.vector_store.MilvusClient") as mock_client_class:
         mock_client = mock.MagicMock()
+        mock_client.query.return_value = []
+        mock_client.insert.return_value = {"insert_count": 1}
+        mock_delete_result = mock.MagicMock()
+        mock_delete_result.delete_count = 1
+        mock_client.delete.return_value = mock_delete_result
         mock_client_class.return_value = mock_client
         yield mock_client
 
 
 @pytest.fixture
-def vector_store(mock_milvus_client):
-    """Create a VectorStore instance with a mocked MilvusClient."""
-    with mock.patch("paperchat.core.vector_store.get_component_logger") as mock_get_logger:
+def vector_store_init_mocks():
+    """Mocks dependencies for VectorStore initialization testing."""
+    with (
+        mock.patch("paperchat.core.vector_store.MilvusClient") as mock_client_class,
+        mock.patch(
+            "paperchat.core.vector_store.VectorStore._get_or_create_collection"
+        ) as mock_get_create,
+        mock.patch("paperchat.core.vector_store.VectorStore._build_indices") as mock_build_indices,
+        mock.patch("paperchat.core.vector_store.get_component_logger") as mock_get_logger,
+        mock.patch(
+            "paperchat.core.vector_store.model.DefaultEmbeddingFunction"
+        ) as mock_embed_fn_class,
+    ):
+        mock_client = mock.MagicMock()
+        mock_client_class.return_value = mock_client
         mock_get_logger.return_value = mock.MagicMock()
-        store = VectorStore()
+        mock_embed_fn = mock.MagicMock()
+        mock_embed_fn.dim = 768
+        mock_embed_fn_class.return_value = mock_embed_fn
+        yield mock_client_class, mock_get_create, mock_build_indices, mock_embed_fn_class
+
+
+@pytest.fixture
+def vector_store(mock_milvus_client, temp_db_path):
+    """Create a VectorStore instance with a mocked MilvusClient, mocking init methods."""
+    with (
+        mock.patch("paperchat.core.vector_store.VectorStore._get_or_create_collection"),
+        mock.patch("paperchat.core.vector_store.VectorStore._build_indices"),
+        mock.patch("paperchat.core.vector_store.get_component_logger") as mock_get_logger,
+        mock.patch(
+            "paperchat.core.vector_store.model.DefaultEmbeddingFunction"
+        ) as mock_embed_fn_class,
+    ):
+        mock_get_logger.return_value = mock.MagicMock()
+        mock_embed_fn = mock.MagicMock()
+        mock_embed_fn.dim = 768
+        mock_embed_fn.encode_queries.return_value = [np.array([0.1] * 768)]
+        mock_embed_fn_class.return_value = mock_embed_fn
+        store = VectorStore(db_path=temp_db_path)
         store.client = mock_milvus_client
+        store._embed_fn = mock_embed_fn
+        store.main_schema = store._define_main_schema()
+        store.metadata_schema = store._define_metadata_schema()
         yield store
 
 
-def test_init_connects_to_milvus():
-    """Test that initialization connects to Milvus."""
-    with (
-        mock.patch("paperchat.core.vector_store.MilvusClient") as mock_client_class,
-        mock.patch("paperchat.core.vector_store.VectorStore.build_index"),
-        mock.patch("paperchat.core.vector_store.VectorStore.get_or_create_collection"),
-        mock.patch("paperchat.core.vector_store.get_component_logger") as mock_get_logger,
-    ):
-        mock_get_logger.return_value = mock.MagicMock()
-        mock_client = mock.MagicMock()
-        mock_client_class.return_value = mock_client
-
-        store = VectorStore()
-
-        expected_db_path = str(Path.home() / ".paperchat" / "paperchat.db")
-        assert store.db_path == expected_db_path
-        assert store.collection_name == "paperchat_docs"
-        mock_client_class.assert_called_once_with(uri=store.db_path)
-
-
-def test_define_schema(vector_store):
-    """Test that the schema is defined correctly."""
-    schema = vector_store._define_schema()
-
-    assert isinstance(schema, CollectionSchema)
-    field_names = [field.name for field in schema.fields]
-    assert "pk" in field_names
-    assert "chunk_id" in field_names
-    assert "embedding" in field_names
-    assert "text" in field_names
-    assert "label" in field_names
-    assert "page_numbers" in field_names
-    assert "headings" in field_names
-    assert "source" in field_names
-
-
-def test_get_or_create_collection(vector_store):
-    """Test creating a collection if it doesn't exist."""
-    vector_store.client.reset_mock()
-
-    vector_store.client.has_collection.return_value = False
-
-    vector_store.get_or_create_collection()
-
-    vector_store.client.has_collection.assert_called_once_with(vector_store.collection_name)
-    vector_store.client.create_collection.assert_called_once_with(
-        collection_name=vector_store.collection_name, schema=vector_store.schema
+def test_init_connects_and_sets_up(vector_store_init_mocks, temp_db_path):
+    """Test initialization connects, creates collections, and builds indices."""
+    (mock_client_class, mock_get_create, mock_build_indices, mock_embed_fn_class) = (
+        vector_store_init_mocks
     )
 
+    store = VectorStore(db_path=temp_db_path)
 
-def test_get_or_create_collection_existing(vector_store):
-    """Test not creating a collection if it already exists."""
-    vector_store.client.reset_mock()
-    vector_store.client.has_collection.return_value = True
-    vector_store.get_or_create_collection()
-    vector_store.client.has_collection.assert_called_once_with(vector_store.collection_name)
-    vector_store.client.create_collection.assert_not_called()
+    mock_client_class.assert_called_once_with(uri=temp_db_path)
+    assert store.client == mock_client_class.return_value
+    assert store.db_path == temp_db_path
+    assert store.collection_name == VectorStore.DEFAULT_COLLECTION_NAME
+    assert store.metadata_collection_name == VectorStore.METADATA_COLLECTION_NAME
 
+    mock_embed_fn_class.assert_called_once()
+    assert store.embedding_dim == 768
 
-def test_build_index(vector_store):
-    """Test building an index."""
-    vector_store.client.reset_mock()
-
-    mock_index_params = mock.MagicMock()
-    vector_store.client.prepare_index_params.return_value = mock_index_params
-
-    vector_store.build_index()
-
-    vector_store.client.prepare_index_params.assert_called_once()
-    mock_index_params.add_index.assert_called_once_with(
-        field_name="embedding", index_type="IVF_FLAT", metric_type="COSINE", params={"nlist": 128}
+    assert mock_get_create.call_count == 2
+    mock_get_create.assert_has_calls(
+        [
+            mock.call(store.collection_name, mock.ANY),
+            mock.call(store.metadata_collection_name, mock.ANY),
+        ],
+        any_order=True,
     )
-    vector_store.client.create_index.assert_called_once_with(
-        collection_name=vector_store.collection_name, index_params=mock_index_params
-    )
+    assert isinstance(mock_get_create.call_args_list[0].args[1], CollectionSchema)
+    assert isinstance(mock_get_create.call_args_list[1].args[1], CollectionSchema)
+
+    mock_build_indices.assert_called_once()
 
 
-def test_add_document(vector_store):
-    """Test adding a document."""
-    pdf_path = "/path/to/test.pdf"
-    mock_process_result = [{"chunk_id": "test", "embedding": [0.1, 0.2], "text": "test text"}]
+@mock.patch("paperchat.core.vector_store.datetime")
+def test_add_document_success(mock_dt, vector_store):
+    """Test successfully adding a new document inserts chunks and metadata."""
+    pdf_path = Path("/fake/path/to/document.pdf")
+    source_id = pdf_path.stem
+    mock_now = datetime(2023, 1, 1, 12, 0, 0)
+    mock_dt.now.return_value = mock_now
+    iso_timestamp = mock_now.isoformat()
 
-    # Mock the check for existing document
-    vector_store.client.query.return_value = []
+    mock_chunk_data = [{"chunk_id": "chunk1", "embedding": [0.1], "text": "text1"}]
+    expected_insert_data = [
+        {"chunk_id": "chunk1", "embedding": [0.1], "text": "text1", "source": source_id}
+    ]
+    expected_metadata = [
+        {
+            "source": source_id,
+            "original_filename": pdf_path.name,
+            "date_added": iso_timestamp,
+        }
+    ]
 
     with mock.patch(
-        "paperchat.core.vector_store.process_pdf_document", return_value=mock_process_result
-    ):
-        result = vector_store.add_document(pdf_path)
+        "paperchat.core.vector_store.process_pdf_document", return_value=mock_chunk_data
+    ) as mock_process:
+        vector_store.client.reset_mock()
+        vector_store.client.query.return_value = []
+        vector_store.client.insert.side_effect = [
+            {"insert_count": len(expected_insert_data)},
+            {"insert_count": 1},
+        ]
+
+        result = vector_store.add_document(str(pdf_path))
 
         assert result is True
-        vector_store.client.query.assert_called_once()
-        vector_store.client.insert.assert_called_once_with(
-            collection_name=vector_store.collection_name, data=mock_process_result
+        vector_store.client.query.assert_called_once_with(
+            collection_name=vector_store.metadata_collection_name,
+            filter=f'source == "{source_id}"',
+            output_fields=["source"],
+            limit=1,
+        )
+        mock_process.assert_called_once()
+        assert vector_store.client.insert.call_count == 2
+        vector_store.client.insert.assert_has_calls(
+            [
+                mock.call(collection_name=vector_store.collection_name, data=expected_insert_data),
+                mock.call(
+                    collection_name=vector_store.metadata_collection_name, data=expected_metadata
+                ),
+            ]
         )
 
 
 def test_add_document_already_exists(vector_store):
-    """Test adding a document that already exists."""
-    pdf_path = "/path/to/test.pdf"
+    """Test adding a document that already exists skips processing and insertion."""
+    pdf_path = Path("/path/to/existing.pdf")
+    source_id = pdf_path.stem
+    vector_store.client.reset_mock()
+    vector_store.client.query.return_value = [{"source": source_id}]
 
-    # Mock the check for existing document - return a result indicating document exists
-    vector_store.client.query.return_value = [{"source": "test"}]
+    with mock.patch("paperchat.core.vector_store.process_pdf_document") as mock_process:
+        result = vector_store.add_document(str(pdf_path))
 
-    result = vector_store.add_document(pdf_path)
+        assert result is True
+        vector_store.client.query.assert_called_once_with(
+            collection_name=vector_store.metadata_collection_name,
+            filter=f'source == "{source_id}"',
+            output_fields=["source"],
+            limit=1,
+        )
+        mock_process.assert_not_called()
+        vector_store.client.insert.assert_not_called()
+        vector_store.logger.info.assert_any_call(
+            f"Document ID '{source_id}' already exists in metadata. Skipping."
+        )
 
-    assert result is True
+
+@mock.patch("paperchat.core.vector_store.process_pdf_document", return_value=[{"text": "chunk"}])
+def test_add_document_chunk_insert_failure(mock_process, vector_store):
+    """Test failure during chunk insertion logs error and returns False."""
+    pdf_path = Path("/path/to/fail_chunk.pdf")
+    source_id = pdf_path.stem
+    vector_store.client.reset_mock()
+    vector_store.logger.reset_mock()
+    vector_store.client.query.return_value = []
+
+    vector_store.client.insert.side_effect = [
+        {"insert_count": 0, "primary_keys": []},
+        {"insert_count": 1},
+    ]
+
+    result = vector_store.add_document(str(pdf_path))
+
+    assert result is False
     vector_store.client.query.assert_called_once()
-    vector_store.client.insert.assert_not_called()
+    mock_process.assert_called_once()
+    assert vector_store.client.insert.call_count == 1
+    vector_store.client.insert.assert_any_call(
+        collection_name=vector_store.collection_name, data=mock.ANY
+    )
+    vector_store.logger.error.assert_called_once()
+    assert (
+        f"Mismatch in chunk insertion count for {source_id}"
+        in vector_store.logger.error.call_args[0][0]
+    )
 
 
-def test_retrieve(vector_store):
-    """Test retrieving documents."""
+@mock.patch("paperchat.core.vector_store.datetime")
+@mock.patch("paperchat.core.vector_store.process_pdf_document", return_value=[{"text": "chunk"}])
+def test_add_document_metadata_insert_failure(mock_process, mock_dt, vector_store):
+    """Test failure during metadata insertion logs error and returns False."""
+    pdf_path = Path("/path/to/fail_meta.pdf")
+    source_id = pdf_path.stem
+    mock_now = datetime(2023, 1, 1, 12, 0, 0)
+    mock_dt.now.return_value = mock_now
+
+    vector_store.client.reset_mock()
+    vector_store.logger.reset_mock()
+    vector_store.client.query.return_value = []
+
+    vector_store.client.insert.side_effect = [
+        {"insert_count": 1},
+        {"insert_count": 0},
+    ]
+
+    result = vector_store.add_document(str(pdf_path))
+
+    assert result is False
+    vector_store.client.query.assert_called_once()
+    mock_process.assert_called_once()
+    assert vector_store.client.insert.call_count == 2
+    vector_store.client.insert.assert_has_calls(
+        [
+            mock.call(collection_name=vector_store.collection_name, data=mock.ANY),
+            mock.call(collection_name=vector_store.metadata_collection_name, data=mock.ANY),
+        ]
+    )
+    vector_store.logger.error.assert_called_once()
+    assert f"Failed to insert metadata for {source_id}" in vector_store.logger.error.call_args[0][0]
+
+
+def test_retrieve_success(vector_store):
+    """Test retrieving documents successfully."""
     query_text = "test query"
-    expected_results = [{"text": "result", "pk": 1}]
-    vector_store.client.search.return_value = expected_results
+    expected_results = [{"entity": {"text": "result", "pk": 1, "source": "s1"}, "distance": 0.9}]
+    vector_store.client.reset_mock()
+    vector_store.client.search.return_value = [expected_results]
 
-    with mock.patch.object(vector_store, "_embed_fn") as mock_embed_fn:
-        mock_embed_fn.encode_queries.return_value = [np.array([0.1, 0.2])]
+    output_fields = [f.name for f in vector_store.main_schema.fields if f.name != "embedding"]
 
-        results = vector_store.retrieve(query_text)
+    results = vector_store.retrieve(query_text)
 
-        assert results == expected_results
-        mock_embed_fn.encode_queries.assert_called_once_with([query_text])
-        vector_store.client.search.assert_called_once()
+    assert results == [expected_results]
+    vector_store._embed_fn.encode_queries.assert_called_once_with([query_text])
+    vector_store.client.search.assert_called_once()
+    search_args = vector_store.client.search.call_args
+    assert search_args.kwargs["collection_name"] == vector_store.collection_name
+    assert np.array_equal(
+        search_args.kwargs["data"][0], vector_store._embed_fn.encode_queries.return_value[0]
+    )
+    assert search_args.kwargs["limit"] == DEFAULT_SIMILARITY_TOP_K
+    assert search_args.kwargs["output_fields"] == output_fields
+    assert "filter" not in search_args.kwargs or search_args.kwargs["filter"] is None
+    assert search_args.kwargs["search_params"]["metric_type"] == "COSINE"
+
+
+def test_retrieve_with_filter_and_custom_params(vector_store):
+    """Test retrieve with a filter expression and custom top_k/threshold."""
+    query_text = "filtered query"
+    filter_expr = "source == 'doc1'"
+    custom_k = 3
+    custom_threshold = 0.5
+    custom_output_fields = ["text", "source"]
+    expected_results = [{"entity": {"text": "filtered result", "source": "doc1"}, "distance": 0.6}]
+    vector_store.client.reset_mock()
+    vector_store.client.search.return_value = [expected_results]
+
+    results = vector_store.retrieve(
+        query_text,
+        top_k=custom_k,
+        threshold=custom_threshold,
+        output_fields=custom_output_fields,
+        filter_expression=filter_expr,
+    )
+
+    assert results == [expected_results]
+    vector_store._embed_fn.encode_queries.assert_called_once_with([query_text])
+    vector_store.client.search.assert_called_once()
+    search_args = vector_store.client.search.call_args
+    assert search_args.kwargs["collection_name"] == vector_store.collection_name
+    assert search_args.kwargs["limit"] == custom_k
+    assert search_args.kwargs["output_fields"] == custom_output_fields
+    assert search_args.kwargs["filter"] == filter_expr
+    assert search_args.kwargs["search_params"]["radius"] == custom_threshold
+
+
+def test_retrieve_embedding_failure(vector_store):
+    """Test retrieve returns empty list if embedding fails."""
+    vector_store._embed_fn.encode_queries.side_effect = Exception("Embedding error")
+    vector_store.client.reset_mock()
+    vector_store.logger.reset_mock()
+
+    results = vector_store.retrieve("query")
+
+    assert results == []
+    vector_store.client.search.assert_not_called()
+    vector_store.logger.exception.assert_called_once()
+
+
+def test_retrieve_search_failure(vector_store):
+    """Test retrieve returns empty list if search fails."""
+    vector_store.client.search.side_effect = Exception("Search error")
+    vector_store.client.reset_mock()
+    vector_store.logger.reset_mock()
+
+    results = vector_store.retrieve("query")
+
+    assert results == []
+    vector_store.client.search.assert_called_once()
+    vector_store.logger.exception.assert_called_once()
+
+
+def test_list_documents_success(vector_store):
+    """Test listing documents successfully."""
+    expected_metadata = [
+        {"source": "doc1", "original_filename": "doc1.pdf", "date_added": "t1"},
+        {"source": "doc2", "original_filename": "doc2.pdf", "date_added": "t2"},
+    ]
+    vector_store.client.reset_mock()
+    vector_store.client.query.return_value = expected_metadata
+
+    results = vector_store.list_documents()
+
+    assert results == expected_metadata
+    vector_store.client.query.assert_called_once_with(
+        collection_name=vector_store.metadata_collection_name,
+        output_fields=["source", "original_filename", "date_added"],
+        limit=100,
+    )
+
+
+def test_list_documents_failure(vector_store):
+    """Test listing documents returns empty list on failure."""
+    vector_store.client.reset_mock()
+    vector_store.logger.reset_mock()
+    vector_store.client.query.side_effect = Exception("Query failed")
+
+    results = vector_store.list_documents()
+
+    assert results == []
+    vector_store.client.query.assert_called_once()
+    vector_store.logger.exception.assert_called_once()
+
+
+def test_remove_document_success(vector_store):
+    """Test removing a document successfully deletes from both collections."""
+    source_id = "doc_to_remove"
+    vector_store.client.reset_mock()
+
+    mock_meta_delete = mock.MagicMock()
+    mock_meta_delete.delete_count = 1
+    mock_chunk_delete = mock.MagicMock()
+    mock_chunk_delete.delete_count = 5
+    vector_store.client.delete.side_effect = [mock_meta_delete, mock_chunk_delete]
+
+    meta_deleted, chunks_deleted = vector_store.remove_document(source_id)
+
+    assert meta_deleted == 1
+    assert chunks_deleted == 5
+    assert vector_store.client.delete.call_count == 2
+    expected_filter = f'source == "{source_id}"'
+    vector_store.client.delete.assert_has_calls(
+        [
+            mock.call(
+                collection_name=vector_store.metadata_collection_name, filter=expected_filter
+            ),
+            mock.call(collection_name=vector_store.collection_name, filter=expected_filter),
+        ]
+    )
+
+
+def test_remove_document_not_found(vector_store):
+    """Test removing a non-existent document returns (0, 0)."""
+    source_id = "doc_not_found"
+    vector_store.client.reset_mock()
+
+    mock_zero_delete = mock.MagicMock()
+    mock_zero_delete.delete_count = 0
+    vector_store.client.delete.return_value = mock_zero_delete
+
+    meta_deleted, chunks_deleted = vector_store.remove_document(source_id)
+
+    assert meta_deleted == 0
+    assert chunks_deleted == 0
+    assert vector_store.client.delete.call_count == 2
+
+
+def test_remove_document_metadata_delete_failure(vector_store):
+    """Test failure during metadata deletion logs error, attempts chunk deletion, returns 0 meta count."""
+    source_id = "fail_meta_delete"
+    vector_store.client.reset_mock()
+    vector_store.logger.reset_mock()
+
+    mock_chunk_delete = mock.MagicMock()
+    mock_chunk_delete.delete_count = 5
+    vector_store.client.delete.side_effect = [
+        Exception("Metadata delete failed"),
+        mock_chunk_delete,
+    ]
+
+    meta_deleted, chunks_deleted = vector_store.remove_document(source_id)
+
+    assert meta_deleted == 0
+    assert chunks_deleted == 5
+    assert vector_store.client.delete.call_count == 2
+    vector_store.logger.exception.assert_called_once()
+    assert (
+        f"Failed to remove from metadata collection for '{source_id}'"
+        in vector_store.logger.exception.call_args[0][0]
+    )
+
+
+def test_remove_document_chunk_delete_failure(vector_store):
+    """Test failure during chunk deletion logs error and returns 0 chunk count."""
+    source_id = "fail_chunk_delete"
+    vector_store.client.reset_mock()
+    vector_store.logger.reset_mock()
+
+    mock_meta_delete = mock.MagicMock()
+    mock_meta_delete.delete_count = 1
+    vector_store.client.delete.side_effect = [mock_meta_delete, Exception("Chunk delete failed")]
+
+    meta_deleted, chunks_deleted = vector_store.remove_document(source_id)
+
+    assert meta_deleted == 1
+    assert chunks_deleted == 0
+    assert vector_store.client.delete.call_count == 2
+    vector_store.logger.exception.assert_called_once()
+    assert (
+        f"Failed to remove chunks from main collection for '{source_id}'"
+        in vector_store.logger.exception.call_args[0][0]
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_delete_mock_attributes(mock_milvus_client):
+    yield
+    if hasattr(mock_milvus_client.delete.return_value, "delete_count"):
+        pass
+    if hasattr(mock_milvus_client.delete.return_value, "primary_keys"):
+        pass


### PR DESCRIPTION
This pull request refactors the `VectorStore` class in `paperchat/core/vector_store.py` to introduce a metadata collection, improve separation of concerns, and enhance functionality. The changes include schema updates, new methods for metadata management, and adjustments to existing methods for better document handling. Additionally, test updates ensure compatibility with the new structure.

### Core Refactoring and Enhancements:
* Introduced a metadata collection (`METADATA_COLLECTION_NAME`) alongside the main document collection to store document metadata separately. Updated the `__init__` method to initialize both collections and their schemas (`_define_main_schema` and `_define_metadata_schema`) and ensure indices are created. [[1]](diffhunk://#diff-cdfe5f037f457739af91fa865203f9b62d460037a6060b9145f54c74180365c7R35-R153) [[2]](diffhunk://#diff-cdfe5f037f457739af91fa865203f9b62d460037a6060b9145f54c74180365c7L226-R406)
* Added methods for metadata management:
  - [`list_documents`](diffhunk://#diff-cdfe5f037f457739af91fa865203f9b62d460037a6060b9145f54c74180365c7L226-R406): Lists all documents in the metadata collection.
  - [`remove_document`](diffhunk://#diff-cdfe5f037f457739af91fa865203f9b62d460037a6060b9145f54c74180365c7L226-R406): Removes a document and its associated metadata and chunks based on a unique identifier.

### Improvements to Document Handling:
* Updated `add_document` to:
  - Check for document existence in the metadata collection before processing.
  - Insert metadata entries after adding document chunks to the main collection.
* Enhanced logging for better traceability of operations, including connection status, processing steps, and error handling.

### Adjustments to Retrieval Logic:
* Updated `retrieve` to use the main schema (`main_schema`) for output fields, ensuring consistency with the refactored structure. Removed unused comments for clarity.

### Test Updates:
* Modified `test_retrieve` in `tests/test_rag_pipeline.py` to include a `threshold` parameter and adapt to the updated `retrieve` method. Adjusted mock results for compatibility.