### PR TITLE
feat(chat): ship the grounded chat and retrieval slice

### DIFF
--- a/backend/paperchat/api/chat.py
+++ b/backend/paperchat/api/chat.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request, status
+
+from paperchat.models.chat import (
+    AssistantBlockResponse,
+    AssistantPayloadResponse,
+    ChatMessageResponse,
+    ChatRequest,
+    ChatTurnResponse,
+    CitationResponse,
+    ConversationListResponse,
+    ConversationResponse,
+    ConversationSummaryResponse,
+)
+from paperchat.services.chat import (
+    AssistantBlockRecord,
+    ChatMessageRecord,
+    ChatServiceProtocol,
+    ChatTurnRecord,
+    CitationRecord,
+    ConversationRecord,
+    ConversationSummaryRecord,
+)
+
+router = APIRouter(prefix="/api/chat")
+
+
+def _get_chat_service(request: Request) -> ChatServiceProtocol:
+    service = getattr(request.app.state, "chat_service", None)
+    if service is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Chat service is not configured.",
+        )
+    return service
+
+
+def _to_citation_response(citation: CitationRecord) -> CitationResponse:
+    return CitationResponse(
+        citation_id=citation.citation_id,
+        chunk_id=citation.chunk_id,
+        document_id=citation.document_id,
+        document_name=citation.document_name,
+        page_numbers=list(citation.page_numbers),
+        headings=list(citation.headings),
+        snippet=citation.snippet,
+    )
+
+
+def _to_block_response(block: AssistantBlockRecord) -> AssistantBlockResponse:
+    return AssistantBlockResponse(
+        text=block.text,
+        citation_ids=list(block.citation_ids),
+    )
+
+
+def _to_message_response(message: ChatMessageRecord) -> ChatMessageResponse:
+    payload = None
+    if message.blocks or message.citations:
+        payload = AssistantPayloadResponse(
+            blocks=[_to_block_response(block) for block in message.blocks],
+            citations=[_to_citation_response(citation) for citation in message.citations],
+        )
+    return ChatMessageResponse(
+        id=message.id,
+        role=message.role,
+        content=message.content,
+        created_at=message.created_at,
+        citations=payload,
+    )
+
+
+def _to_conversation_summary_response(
+    conversation: ConversationSummaryRecord,
+) -> ConversationSummaryResponse:
+    return ConversationSummaryResponse(
+        id=conversation.id,
+        title=conversation.title,
+        updated_at=conversation.updated_at,
+        message_count=conversation.message_count,
+    )
+
+
+def _to_conversation_response(conversation: ConversationRecord) -> ConversationResponse:
+    return ConversationResponse(
+        id=conversation.id,
+        title=conversation.title,
+        created_at=conversation.created_at,
+        updated_at=conversation.updated_at,
+        messages=[_to_message_response(message) for message in conversation.messages],
+    )
+
+
+def _to_chat_turn_response(result: ChatTurnRecord) -> ChatTurnResponse:
+    return ChatTurnResponse(
+        conversation=_to_conversation_summary_response(result.conversation),
+        user_message=_to_message_response(result.user_message),
+        assistant_message=_to_message_response(result.assistant_message),
+        source_document_ids=list(result.source_document_ids),
+    )
+
+
+@router.get("/conversations", response_model=ConversationListResponse)
+def list_conversations(request: Request) -> ConversationListResponse:
+    service = _get_chat_service(request)
+    conversations = [
+        _to_conversation_summary_response(conversation)
+        for conversation in service.list_conversations()
+    ]
+    return ConversationListResponse(conversations=conversations)
+
+
+@router.get("/conversations/{conversation_id}", response_model=ConversationResponse)
+def get_conversation(conversation_id: str, request: Request) -> ConversationResponse:
+    service = _get_chat_service(request)
+    conversation = service.get_conversation(conversation_id=conversation_id)
+    if conversation is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversation not found.")
+    return _to_conversation_response(conversation)
+
+
+@router.post("/messages", response_model=ChatTurnResponse)
+def send_message(payload: ChatRequest, request: Request) -> ChatTurnResponse:
+    service = _get_chat_service(request)
+    try:
+        result = service.send_message(
+            prompt=payload.prompt,
+            conversation_id=payload.conversation_id,
+            document_ids=tuple(payload.document_ids or ()),
+        )
+    except LookupError as error:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(error),
+        ) from error
+    except ValueError as error:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(error),
+        ) from error
+    return _to_chat_turn_response(result)

--- a/backend/paperchat/main.py
+++ b/backend/paperchat/main.py
@@ -7,10 +7,12 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from paperchat.api.bootstrap import router
+from paperchat.api.chat import router as chat_router
 from paperchat.api.documents import router as documents_router
 from paperchat.api.local_files import router as local_files_router
 from paperchat.api.runtime import router as runtime_router
 from paperchat.db.engine import get_session_factory
+from paperchat.services.chat import ChatService, ChatServiceProtocol
 from paperchat.services.docling_ingestion import DoclingDocumentParser
 from paperchat.services.documents import (
     DocumentLifecycleBackend,
@@ -24,12 +26,15 @@ from paperchat.services.ingestion import IngestionCoordinator, IngestionProcesso
 def create_app(
     *,
     document_service: DocumentServiceProtocol | None = None,
+    chat_service: ChatServiceProtocol | None = None,
     start_worker: bool = True,
 ) -> FastAPI:
     service_was_injected = document_service is not None
     coordinator: IngestionCoordinator | None = None
     if document_service is None:
         document_service, coordinator = _build_default_document_service()
+    if chat_service is None:
+        chat_service = _build_default_chat_service()
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
@@ -44,6 +49,7 @@ def create_app(
                 active_document_service = None
                 active_coordinator = None
         app.state.document_service = active_document_service
+        app.state.chat_service = chat_service
         app.state.ingestion_coordinator = active_coordinator
         if active_coordinator is not None and start_worker:
             active_coordinator.start()
@@ -56,12 +62,13 @@ def create_app(
     app = FastAPI(lifespan=lifespan)
     app.add_middleware(
         cast(Any, CORSMiddleware),
-        allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+        allow_origin_regex=r"https?://(localhost|127\.0\.0\.1)(:\d+)?",
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
     )
     app.include_router(router)
+    app.include_router(chat_router)
     app.include_router(documents_router)
     app.include_router(local_files_router)
     app.include_router(runtime_router)
@@ -94,3 +101,10 @@ def _build_default_document_service() -> tuple[
         ),
         coordinator,
     )
+
+
+def _build_default_chat_service() -> ChatServiceProtocol | None:
+    try:
+        return ChatService(session_factory=get_session_factory())
+    except Exception:
+        return None

--- a/backend/paperchat/models/chat.py
+++ b/backend/paperchat/models/chat.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+
+class ChatRole(StrEnum):
+    user = "user"
+    assistant = "assistant"
+
+
+class CitationResponse(BaseModel):
+    citation_id: str
+    chunk_id: str
+    document_id: str
+    document_name: str
+    page_numbers: list[int]
+    headings: list[str]
+    snippet: str
+
+
+class AssistantBlockResponse(BaseModel):
+    text: str
+    citation_ids: list[str]
+
+
+class AssistantPayloadResponse(BaseModel):
+    blocks: list[AssistantBlockResponse]
+    citations: list[CitationResponse]
+
+
+class ChatMessageResponse(BaseModel):
+    id: str
+    role: ChatRole
+    content: str
+    created_at: datetime
+    citations: AssistantPayloadResponse | None = None
+
+
+class ConversationSummaryResponse(BaseModel):
+    id: str
+    title: str | None = None
+    updated_at: datetime
+    message_count: int
+
+
+class ConversationListResponse(BaseModel):
+    conversations: list[ConversationSummaryResponse]
+
+
+class ConversationResponse(BaseModel):
+    id: str
+    title: str | None = None
+    created_at: datetime
+    updated_at: datetime
+    messages: list[ChatMessageResponse]
+
+
+class ChatRequest(BaseModel):
+    prompt: str
+    conversation_id: str | None = None
+    document_ids: list[str] | None = None
+
+
+class ChatTurnResponse(BaseModel):
+    conversation: ConversationSummaryResponse
+    user_message: ChatMessageResponse
+    assistant_message: ChatMessageResponse
+    source_document_ids: list[str]

--- a/backend/paperchat/repositories/documents.py
+++ b/backend/paperchat/repositories/documents.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 
-from sqlalchemy import Select, delete, func, select
+import sqlite_vec
+from sqlalchemy import Select, delete, func, select, text
 from sqlalchemy.orm import Session
 
 from paperchat.db.schema import Document, DocumentChunk, IngestionJob
@@ -18,6 +19,22 @@ class NewChunk:
     headings: tuple[str, ...]
     warning_codes: tuple[str, ...]
     embedding: tuple[float, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievedChunk:
+    chunk_id: str
+    document_id: str
+    document_name: str
+    text: str
+    retrieval_text: str
+    page_numbers: tuple[int, ...]
+    headings: tuple[str, ...]
+    warning_codes: tuple[str, ...]
+    distance: float
+
+
+VECTOR_TABLE_NAME = "vec_chunks"
 
 
 class DocumentRepository:
@@ -65,8 +82,10 @@ class DocumentRepository:
             target = self.get(document)
             if target is None:
                 return
+            VectorChunkRepository(self._session).delete_for_document(target.id)
             self._session.delete(target)
             return
+        VectorChunkRepository(self._session).delete_for_document(document.id)
         self._session.delete(document)
 
     def replace_chunks(
@@ -74,9 +93,12 @@ class DocumentRepository:
         document_id: str,
         chunks: Sequence[DocumentChunk],
     ) -> None:
+        vector_chunks = VectorChunkRepository(self._session)
+        vector_chunks.delete_for_document(document_id)
         self._session.execute(delete(DocumentChunk).where(DocumentChunk.document_id == document_id))
         self._session.add_all(chunks)
         self._session.flush()
+        vector_chunks.upsert_chunks(chunks)
 
 
 class DocumentChunkRepository:
@@ -158,3 +180,189 @@ class IngestionJobRepository:
                 stage=stage,
             )
         )
+
+
+class VectorChunkRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def ensure_search_index_synced(self) -> None:
+        chunk_rows = tuple(
+            self._session.execute(select(DocumentChunk.id, DocumentChunk.embedding)).all()
+        )
+        if not chunk_rows:
+            return
+
+        dimension = len(chunk_rows[0].embedding)
+        if not self._index_exists() or self._count_index_rows() != len(chunk_rows):
+            self._drop_index()
+            self._create_index(dimension)
+            self._session.execute(
+                text(
+                    f"INSERT INTO {VECTOR_TABLE_NAME}(chunk_id, embedding) VALUES "
+                    "(:chunk_id, :embedding)"
+                ),
+                [
+                    {
+                        "chunk_id": chunk_id,
+                        "embedding": sqlite_vec.serialize_float32(list(embedding)),
+                    }
+                    for chunk_id, embedding in chunk_rows
+                ],
+            )
+
+    def upsert_chunks(self, chunks: Sequence[DocumentChunk]) -> None:
+        if not chunks:
+            return
+        if not self._index_exists():
+            self._create_index(len(chunks[0].embedding))
+        self._session.execute(
+            text(
+                f"INSERT OR REPLACE INTO {VECTOR_TABLE_NAME}(chunk_id, embedding) VALUES "
+                "(:chunk_id, :embedding)"
+            ),
+            [
+                {
+                    "chunk_id": chunk.id,
+                    "embedding": sqlite_vec.serialize_float32(list(chunk.embedding)),
+                }
+                for chunk in chunks
+            ],
+        )
+
+    def delete_for_document(self, document_id: str) -> None:
+        if not self._index_exists():
+            return
+        chunk_ids = tuple(
+            self._session.scalars(
+                select(DocumentChunk.id).where(DocumentChunk.document_id == document_id)
+            )
+        )
+        if not chunk_ids:
+            return
+        self._delete_chunk_ids(chunk_ids)
+
+    def search(
+        self,
+        *,
+        query_embedding: Sequence[float],
+        document_ids: tuple[str, ...],
+        limit: int,
+    ) -> tuple[RetrievedChunk, ...]:
+        if not self._index_exists():
+            return ()
+
+        params: dict[str, object] = {
+            "query_embedding": sqlite_vec.serialize_float32(list(query_embedding)),
+            "search_k": self._count_index_rows(),
+        }
+        statement = text(
+            f"""
+            SELECT chunk_id, distance
+            FROM {VECTOR_TABLE_NAME}
+            WHERE {VECTOR_TABLE_NAME}.embedding MATCH :query_embedding AND k = :search_k
+            ORDER BY distance
+            """
+        )
+        distance_rows = tuple(self._session.execute(statement, params).mappings())
+        if not distance_rows:
+            return ()
+
+        chunk_ids = [str(row["chunk_id"]) for row in distance_rows]
+        metadata_rows = self._session.execute(
+            select(DocumentChunk, Document.display_name)
+            .join(Document, Document.id == DocumentChunk.document_id)
+            .where(DocumentChunk.id.in_(chunk_ids))
+        )
+        metadata_by_chunk_id = {
+            chunk.id: (chunk, document_name) for chunk, document_name in metadata_rows
+        }
+        results: list[RetrievedChunk] = []
+        allowed_document_ids = set(document_ids)
+        for row in distance_rows:
+            chunk_id = str(row["chunk_id"])
+            metadata = metadata_by_chunk_id.get(chunk_id)
+            if metadata is None:
+                continue
+            chunk, document_name = metadata
+            document = self._session.get(Document, chunk.document_id)
+            if document is None or document.status != "ready":
+                continue
+            if allowed_document_ids and chunk.document_id not in allowed_document_ids:
+                continue
+            results.append(
+                _to_retrieved_chunk(
+                    chunk_id=chunk_id,
+                    distance=float(row["distance"]),
+                    chunk=chunk,
+                    document_name=document_name,
+                )
+            )
+            if len(results) >= limit:
+                break
+        return tuple(results)
+
+    def _index_exists(self) -> bool:
+        return (
+            self._session.execute(
+                text("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = :name LIMIT 1"),
+                {"name": VECTOR_TABLE_NAME},
+            ).scalar()
+            is not None
+        )
+
+    def _count_index_rows(self) -> int:
+        if not self._index_exists():
+            return 0
+        return (
+            self._session.execute(text(f"SELECT COUNT(*) FROM {VECTOR_TABLE_NAME}")).scalar() or 0
+        )
+
+    def _create_index(self, dimension: int) -> None:
+        self._session.execute(
+            text(
+                f"""
+                CREATE VIRTUAL TABLE {VECTOR_TABLE_NAME}
+                USING vec0(chunk_id TEXT PRIMARY KEY, embedding FLOAT[{dimension}])
+                """
+            )
+        )
+
+    def _drop_index(self) -> None:
+        if not self._index_exists():
+            return
+        self._session.execute(text(f"DROP TABLE {VECTOR_TABLE_NAME}"))
+
+    def _delete_chunk_ids(self, chunk_ids: Sequence[str]) -> None:
+        if not chunk_ids:
+            return
+        placeholders = []
+        params: dict[str, object] = {}
+        for index, chunk_id in enumerate(chunk_ids):
+            key = f"chunk_id_{index}"
+            placeholders.append(f":{key}")
+            params[key] = chunk_id
+        self._session.execute(
+            text(f"DELETE FROM {VECTOR_TABLE_NAME} WHERE chunk_id IN ({', '.join(placeholders)})"),
+            params,
+        )
+
+
+def _to_retrieved_chunk(
+    *,
+    chunk_id: str,
+    distance: float,
+    chunk: DocumentChunk,
+    document_name: str,
+) -> RetrievedChunk:
+    return RetrievedChunk(
+        chunk_id=chunk_id,
+        document_id=chunk.document_id,
+        document_name=document_name,
+        text=chunk.text,
+        retrieval_text=chunk.retrieval_text,
+        page_numbers=tuple(chunk.page_numbers),
+        headings=tuple(chunk.headings),
+        warning_codes=tuple(chunk.warning_codes),
+        distance=distance,
+    )

--- a/backend/paperchat/services/chat.py
+++ b/backend/paperchat/services/chat.py
@@ -1,0 +1,475 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from paperchat.db.schema import Conversation, Document, Message
+from paperchat.models.chat import ChatRole
+from paperchat.repositories.documents import RetrievedChunk, VectorChunkRepository
+from paperchat.services.embeddings import EmbeddingGemmaEmbeddingService, EmbeddingService
+
+DEFAULT_CHAT_RESULT_LIMIT = 3
+MAX_CONVERSATION_TITLE_LENGTH = 60
+MAX_SNIPPET_LENGTH = 220
+
+
+@dataclass(frozen=True, slots=True)
+class CitationRecord:
+    citation_id: str
+    chunk_id: str
+    document_id: str
+    document_name: str
+    page_numbers: tuple[int, ...]
+    headings: tuple[str, ...]
+    snippet: str
+
+
+@dataclass(frozen=True, slots=True)
+class AssistantBlockRecord:
+    text: str
+    citation_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ChatMessageRecord:
+    id: str
+    role: ChatRole
+    content: str
+    created_at: datetime
+    blocks: tuple[AssistantBlockRecord, ...] = ()
+    citations: tuple[CitationRecord, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationSummaryRecord:
+    id: str
+    title: str | None
+    updated_at: datetime
+    message_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationRecord:
+    id: str
+    title: str | None
+    created_at: datetime
+    updated_at: datetime
+    messages: tuple[ChatMessageRecord, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ChatTurnRecord:
+    conversation: ConversationSummaryRecord
+    user_message: ChatMessageRecord
+    assistant_message: ChatMessageRecord
+    source_document_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AnswerDraft:
+    content: str
+    blocks: tuple[AssistantBlockRecord, ...]
+    citations: tuple[CitationRecord, ...]
+
+
+class AnswerServiceProtocol(Protocol):
+    def generate_answer(
+        self,
+        *,
+        prompt: str,
+        chunks: tuple[RetrievedChunk, ...],
+    ) -> AnswerDraft: ...
+
+
+class ChatServiceProtocol(Protocol):
+    def list_conversations(self) -> tuple[ConversationSummaryRecord, ...]: ...
+
+    def get_conversation(self, *, conversation_id: str) -> ConversationRecord | None: ...
+
+    def send_message(
+        self,
+        *,
+        prompt: str,
+        conversation_id: str | None = None,
+        document_ids: tuple[str, ...] = (),
+    ) -> ChatTurnRecord: ...
+
+
+class DeterministicAnswerService:
+    """Small grounded answer formatter used until a real provider is added."""
+
+    def generate_answer(
+        self,
+        *,
+        prompt: str,
+        chunks: tuple[RetrievedChunk, ...],
+    ) -> AnswerDraft:
+        if not chunks:
+            block = AssistantBlockRecord(
+                text=(
+                    f'I could not find grounded support for "{prompt}" in the selected documents.'
+                ),
+                citation_ids=(),
+            )
+            return AnswerDraft(
+                content=block.text,
+                blocks=(block,),
+                citations=(),
+            )
+
+        blocks = [
+            AssistantBlockRecord(
+                text=f'Grounded notes for "{prompt}":',
+                citation_ids=(),
+            )
+        ]
+        citations: list[CitationRecord] = []
+        for index, chunk in enumerate(chunks, start=1):
+            citation_id = f"c{index}"
+            snippet = _snippet(chunk.retrieval_text)
+            citations.append(
+                CitationRecord(
+                    citation_id=citation_id,
+                    chunk_id=chunk.chunk_id,
+                    document_id=chunk.document_id,
+                    document_name=chunk.document_name,
+                    page_numbers=chunk.page_numbers,
+                    headings=chunk.headings,
+                    snippet=snippet,
+                )
+            )
+            page_label = _page_label(chunk.page_numbers)
+            heading_prefix = f"{chunk.headings[0]}: " if chunk.headings else ""
+            blocks.append(
+                AssistantBlockRecord(
+                    text=f"{chunk.document_name} ({page_label}) {heading_prefix}{snippet}",
+                    citation_ids=(citation_id,),
+                )
+            )
+
+        return AnswerDraft(
+            content="\n\n".join(block.text for block in blocks),
+            blocks=tuple(blocks),
+            citations=tuple(citations),
+        )
+
+
+class ChatService:
+    def __init__(
+        self,
+        *,
+        session_factory: sessionmaker[Session],
+        embedder: EmbeddingService | None = None,
+        answer_service: AnswerServiceProtocol | None = None,
+    ) -> None:
+        self._session_factory = session_factory
+        self._embedder = embedder or EmbeddingGemmaEmbeddingService()
+        self._answer_service = answer_service or DeterministicAnswerService()
+        self._ensure_search_index()
+
+    def list_conversations(self) -> tuple[ConversationSummaryRecord, ...]:
+        with self._session_factory() as session:
+            statement = (
+                select(Conversation, func.count(Message.id))
+                .outerjoin(Message, Message.conversation_id == Conversation.id)
+                .group_by(Conversation.id)
+                .order_by(Conversation.updated_at.desc())
+            )
+            rows = session.execute(statement)
+            return tuple(
+                ConversationSummaryRecord(
+                    id=conversation.id,
+                    title=conversation.title,
+                    updated_at=conversation.updated_at,
+                    message_count=message_count,
+                )
+                for conversation, message_count in rows
+            )
+
+    def get_conversation(self, *, conversation_id: str) -> ConversationRecord | None:
+        with self._session_factory() as session:
+            conversation = session.get(Conversation, conversation_id)
+            if conversation is None:
+                return None
+            statement = (
+                select(Message)
+                .where(Message.conversation_id == conversation_id)
+                .order_by(Message.message_index.asc())
+            )
+            messages = tuple(session.scalars(statement))
+            return ConversationRecord(
+                id=conversation.id,
+                title=conversation.title,
+                created_at=conversation.created_at,
+                updated_at=conversation.updated_at,
+                messages=tuple(_to_message_record(message) for message in messages),
+            )
+
+    def send_message(
+        self,
+        *,
+        prompt: str,
+        conversation_id: str | None = None,
+        document_ids: tuple[str, ...] = (),
+    ) -> ChatTurnRecord:
+        trimmed_prompt = prompt.strip()
+        if not trimmed_prompt:
+            raise ValueError("Prompt cannot be empty.")
+
+        source_documents = self._resolve_source_documents(document_ids=document_ids)
+        self._ensure_search_index()
+        retrieved_chunks = self._retrieve_chunks(
+            prompt=trimmed_prompt,
+            document_ids=tuple(document.id for document in source_documents),
+        )
+        answer = self._answer_service.generate_answer(
+            prompt=trimmed_prompt, chunks=retrieved_chunks
+        )
+        _validate_answer(answer=answer, retrieved_chunks=retrieved_chunks)
+
+        stored_turn = self._store_turn(
+            prompt=trimmed_prompt,
+            conversation_id=conversation_id,
+            answer=answer,
+        )
+        return ChatTurnRecord(
+            conversation=stored_turn.conversation,
+            user_message=stored_turn.user_message,
+            assistant_message=stored_turn.assistant_message,
+            source_document_ids=tuple(document.id for document in source_documents),
+        )
+
+    def _resolve_source_documents(self, *, document_ids: tuple[str, ...]) -> tuple[Document, ...]:
+        with self._session_factory() as session:
+            statement = select(Document).where(Document.status == "ready")
+            if document_ids:
+                statement = statement.where(Document.id.in_(document_ids))
+            documents = tuple(session.scalars(statement.order_by(Document.created_at.desc())))
+            if not documents:
+                if document_ids:
+                    msg = "Selected documents must exist and be ready before chat can use them."
+                    raise ValueError(msg)
+                msg = "At least one ready document is required before chat can run."
+                raise ValueError(msg)
+            if document_ids and len(documents) != len(set(document_ids)):
+                msg = "Selected documents must exist and be ready before chat can use them."
+                raise ValueError(msg)
+            return documents
+
+    def _retrieve_chunks(
+        self,
+        *,
+        prompt: str,
+        document_ids: tuple[str, ...],
+    ) -> tuple[RetrievedChunk, ...]:
+        query_embedding = self._embedder.embed_query(prompt)
+        with self._session_factory() as session:
+            repository = VectorChunkRepository(session)
+            repository.ensure_search_index_synced()
+            return repository.search(
+                query_embedding=query_embedding,
+                document_ids=document_ids,
+                limit=DEFAULT_CHAT_RESULT_LIMIT,
+            )
+
+    def _store_turn(
+        self,
+        *,
+        prompt: str,
+        conversation_id: str | None,
+        answer: AnswerDraft,
+    ) -> StoredTurn:
+        with self._session_factory.begin() as session:
+            conversation = _get_or_create_conversation(
+                session=session,
+                conversation_id=conversation_id,
+                first_prompt=prompt,
+            )
+            user_message = Message(
+                conversation_id=conversation.id,
+                message_index=_next_message_index(session, conversation.id),
+                role=ChatRole.user,
+                content=prompt,
+                citations=None,
+            )
+            session.add(user_message)
+            session.flush()
+
+            assistant_message = Message(
+                conversation_id=conversation.id,
+                message_index=user_message.message_index + 1,
+                role=ChatRole.assistant,
+                content=answer.content,
+                citations={
+                    "blocks": [_block_to_dict(block) for block in answer.blocks],
+                    "citations": [_citation_to_dict(citation) for citation in answer.citations],
+                },
+            )
+            conversation.updated_at = _utcnow()
+            session.add(assistant_message)
+            session.flush()
+            message_count = session.scalar(
+                select(func.count(Message.id)).where(Message.conversation_id == conversation.id)
+            )
+            summary = ConversationSummaryRecord(
+                id=conversation.id,
+                title=conversation.title,
+                updated_at=conversation.updated_at,
+                message_count=message_count or 0,
+            )
+            return StoredTurn(
+                conversation=summary,
+                user_message=_to_message_record(user_message),
+                assistant_message=_to_message_record(assistant_message),
+            )
+
+    def _ensure_search_index(self) -> None:
+        with self._session_factory.begin() as session:
+            VectorChunkRepository(session).ensure_search_index_synced()
+
+
+@dataclass(frozen=True, slots=True)
+class StoredTurn:
+    conversation: ConversationSummaryRecord
+    user_message: ChatMessageRecord
+    assistant_message: ChatMessageRecord
+
+
+def _get_or_create_conversation(
+    *,
+    session: Session,
+    conversation_id: str | None,
+    first_prompt: str,
+) -> Conversation:
+    if conversation_id is not None:
+        conversation = session.get(Conversation, conversation_id)
+        if conversation is None:
+            msg = f"Conversation {conversation_id} was not found."
+            raise LookupError(msg)
+        return conversation
+
+    conversation = Conversation(title=_conversation_title(first_prompt))
+    session.add(conversation)
+    session.flush()
+    return conversation
+
+
+def _next_message_index(session: Session, conversation_id: str) -> int:
+    current = session.scalar(
+        select(func.max(Message.message_index)).where(Message.conversation_id == conversation_id)
+    )
+    return (current or -1) + 1
+
+
+def _conversation_title(prompt: str) -> str:
+    trimmed = " ".join(prompt.strip().split())
+    if len(trimmed) <= MAX_CONVERSATION_TITLE_LENGTH:
+        return trimmed
+    return trimmed[: MAX_CONVERSATION_TITLE_LENGTH - 1].rstrip() + "…"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _snippet(text: str) -> str:
+    collapsed = " ".join(text.split())
+    if len(collapsed) <= MAX_SNIPPET_LENGTH:
+        return collapsed
+    return collapsed[: MAX_SNIPPET_LENGTH - 3].rstrip() + "..."
+
+
+def _page_label(page_numbers: tuple[int, ...]) -> str:
+    if not page_numbers:
+        return "pages unknown"
+    if len(page_numbers) == 1:
+        return f"page {page_numbers[0]}"
+    return "pages " + ", ".join(str(page_number) for page_number in page_numbers)
+
+
+def _block_to_dict(block: AssistantBlockRecord) -> dict[str, object]:
+    return {
+        "text": block.text,
+        "citation_ids": list(block.citation_ids),
+    }
+
+
+def _citation_to_dict(citation: CitationRecord) -> dict[str, object]:
+    return {
+        "citation_id": citation.citation_id,
+        "chunk_id": citation.chunk_id,
+        "document_id": citation.document_id,
+        "document_name": citation.document_name,
+        "page_numbers": list(citation.page_numbers),
+        "headings": list(citation.headings),
+        "snippet": citation.snippet,
+    }
+
+
+def _to_message_record(message: Message) -> ChatMessageRecord:
+    blocks: tuple[AssistantBlockRecord, ...] = ()
+    citations: tuple[CitationRecord, ...] = ()
+    if message.citations:
+        raw_blocks = message.citations.get("blocks", [])
+        raw_citations = message.citations.get("citations", [])
+        blocks = tuple(
+            AssistantBlockRecord(
+                text=str(block["text"]),
+                citation_ids=tuple(str(citation_id) for citation_id in block["citation_ids"]),
+            )
+            for block in raw_blocks
+        )
+        citations = tuple(
+            CitationRecord(
+                citation_id=str(citation["citation_id"]),
+                chunk_id=str(citation["chunk_id"]),
+                document_id=str(citation["document_id"]),
+                document_name=str(citation["document_name"]),
+                page_numbers=tuple(int(page_number) for page_number in citation["page_numbers"]),
+                headings=tuple(str(heading) for heading in citation["headings"]),
+                snippet=str(citation["snippet"]),
+            )
+            for citation in raw_citations
+        )
+    return ChatMessageRecord(
+        id=message.id,
+        role=ChatRole(message.role),
+        content=message.content,
+        created_at=message.created_at,
+        blocks=blocks,
+        citations=citations,
+    )
+
+
+def _validate_answer(
+    *,
+    answer: AnswerDraft,
+    retrieved_chunks: tuple[RetrievedChunk, ...],
+) -> None:
+    retrieved_by_chunk_id = {chunk.chunk_id: chunk for chunk in retrieved_chunks}
+    citations_by_id = {citation.citation_id: citation for citation in answer.citations}
+
+    for block in answer.blocks:
+        for citation_id in block.citation_ids:
+            if citation_id not in citations_by_id:
+                msg = f"Assistant response referenced unknown citation id `{citation_id}`."
+                raise ValueError(msg)
+
+    for citation in answer.citations:
+        chunk = retrieved_by_chunk_id.get(citation.chunk_id)
+        if chunk is None:
+            msg = f"Citation `{citation.citation_id}` did not map to a retrieved chunk."
+            raise ValueError(msg)
+        if citation.document_id != chunk.document_id:
+            msg = f"Citation `{citation.citation_id}` did not match the retrieved document."
+            raise ValueError(msg)
+        if citation.page_numbers != chunk.page_numbers:
+            msg = f"Citation `{citation.citation_id}` did not match the retrieved page numbers."
+            raise ValueError(msg)
+        if citation.headings != chunk.headings:
+            msg = f"Citation `{citation.citation_id}` did not match the retrieved headings."
+            raise ValueError(msg)

--- a/backend/tests/api/test_chat_routes.py
+++ b/backend/tests/api/test_chat_routes.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from collections import deque
+from datetime import UTC, datetime
+from typing import Any, cast
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from paperchat.main import create_app
+from paperchat.models.chat import ChatRole
+from paperchat.services.chat import (
+    AssistantBlockRecord,
+    ChatMessageRecord,
+    ChatTurnRecord,
+    CitationRecord,
+    ConversationRecord,
+    ConversationSummaryRecord,
+)
+
+
+def make_conversation_summary() -> ConversationSummaryRecord:
+    return ConversationSummaryRecord(
+        id=str(uuid4()),
+        title="Attention summary",
+        updated_at=datetime.now(UTC),
+        message_count=2,
+    )
+
+
+def make_user_message() -> ChatMessageRecord:
+    return ChatMessageRecord(
+        id=str(uuid4()),
+        role=ChatRole.user,
+        content="How does attention work?",
+        created_at=datetime.now(UTC),
+    )
+
+
+def make_assistant_message(*, document_id: str) -> ChatMessageRecord:
+    return ChatMessageRecord(
+        id=str(uuid4()),
+        role=ChatRole.assistant,
+        content="Grounded notes for attention.",
+        created_at=datetime.now(UTC),
+        blocks=(
+            AssistantBlockRecord(
+                text="Grounded notes for attention.",
+                citation_ids=("c1",),
+            ),
+        ),
+        citations=(
+            CitationRecord(
+                citation_id="c1",
+                chunk_id=str(uuid4()),
+                document_id=document_id,
+                document_name="attention.pdf",
+                page_numbers=(1,),
+                headings=("Overview",),
+                snippet="Transformers use attention to connect distant tokens.",
+            ),
+        ),
+    )
+
+
+class FakeDocumentService:
+    def recover_interrupted_jobs(self) -> int:
+        return 0
+
+
+class FakeChatService:
+    def __init__(self) -> None:
+        summary = make_conversation_summary()
+        user_message = make_user_message()
+        assistant_message = make_assistant_message(document_id=str(uuid4()))
+        self.conversation = ConversationRecord(
+            id=summary.id,
+            title=summary.title,
+            created_at=summary.updated_at,
+            updated_at=summary.updated_at,
+            messages=(user_message, assistant_message),
+        )
+        self.summaries = deque([summary])
+        self.turn = ChatTurnRecord(
+            conversation=summary,
+            user_message=user_message,
+            assistant_message=assistant_message,
+            source_document_ids=(assistant_message.citations[0].document_id,),
+        )
+
+    def list_conversations(self) -> tuple[ConversationSummaryRecord, ...]:
+        return tuple(self.summaries)
+
+    def get_conversation(self, *, conversation_id: str) -> ConversationRecord | None:
+        if conversation_id == self.conversation.id:
+            return self.conversation
+        return None
+
+    def send_message(
+        self,
+        *,
+        prompt: str,
+        conversation_id: str | None = None,
+        document_ids: tuple[str, ...] = (),
+    ) -> ChatTurnRecord:
+        del conversation_id, document_ids
+        if not prompt.strip():
+            raise ValueError("Prompt cannot be empty.")
+        return self.turn
+
+
+def test_chat_routes_cover_list_detail_and_send() -> None:
+    app = create_app(
+        document_service=cast(Any, FakeDocumentService()),
+        chat_service=cast(Any, FakeChatService()),
+    )
+
+    with TestClient(app) as client:
+        list_response = client.get("/api/chat/conversations")
+        assert list_response.status_code == 200
+        assert len(list_response.json()["conversations"]) == 1
+
+        conversation_id = list_response.json()["conversations"][0]["id"]
+        detail_response = client.get(f"/api/chat/conversations/{conversation_id}")
+        assert detail_response.status_code == 200
+        assert len(detail_response.json()["messages"]) == 2
+
+        send_response = client.post(
+            "/api/chat/messages",
+            json={"prompt": "How does attention work?"},
+        )
+        assert send_response.status_code == 200
+        body = send_response.json()
+        assert (
+            body["assistant_message"]["citations"]["citations"][0]["document_name"]
+            == "attention.pdf"
+        )
+
+
+def test_get_conversation_returns_404_for_unknown_conversation() -> None:
+    app = create_app(
+        document_service=cast(Any, FakeDocumentService()),
+        chat_service=cast(Any, FakeChatService()),
+    )
+
+    with TestClient(app) as client:
+        response = client.get(f"/api/chat/conversations/{uuid4()}")
+
+    assert response.status_code == 404
+
+
+def test_send_message_returns_400_for_empty_prompt() -> None:
+    app = create_app(
+        document_service=cast(Any, FakeDocumentService()),
+        chat_service=cast(Any, FakeChatService()),
+    )
+
+    with TestClient(app) as client:
+        response = client.post("/api/chat/messages", json={"prompt": "   "})
+
+    assert response.status_code == 400

--- a/backend/tests/api/test_cors.py
+++ b/backend/tests/api/test_cors.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from paperchat.main import create_app
+
+
+def test_localhost_dev_origins_are_allowed_for_cors() -> None:
+    with TestClient(create_app()) as client:
+        response = client.options(
+            "/api/runtime",
+            headers={
+                "Origin": "http://127.0.0.1:5174",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://127.0.0.1:5174"

--- a/backend/tests/repositories/test_document_repositories.py
+++ b/backend/tests/repositories/test_document_repositories.py
@@ -5,6 +5,7 @@ from paperchat.repositories.documents import (
     DocumentRepository,
     IngestionJobRepository,
     NewChunk,
+    VectorChunkRepository,
 )
 
 VALID_CONTENT_HASH = "a" * 64
@@ -114,3 +115,59 @@ def test_delete_document_hard_deletes_related_chunks_and_jobs(db_session) -> Non
     assert document_repository.get(document.id) is None
     assert chunk_repository.list_for_document(document.id) == ()
     assert job_repository.get_latest_for_document(document.id) is None
+
+
+def test_vector_chunk_repository_searches_ready_documents(db_session) -> None:
+    document_repository = DocumentRepository(db_session)
+    chunk_repository = DocumentChunkRepository(db_session)
+
+    first = document_repository.create(
+        content_hash="b" * 64,
+        original_filename="attention.pdf",
+        display_name="Attention",
+        file_path="/tmp/attention.pdf",
+        status="ready",
+    )
+    second = document_repository.create(
+        content_hash="c" * 64,
+        original_filename="bert.pdf",
+        display_name="BERT",
+        file_path="/tmp/bert.pdf",
+        status="ready",
+    )
+    chunk_repository.replace_for_document(
+        first.id,
+        (
+            NewChunk(
+                chunk_index=0,
+                text="attention text",
+                retrieval_text="attention text",
+                page_numbers=(1,),
+                headings=("Overview",),
+                warning_codes=(),
+                embedding=(1.0, 0.0),
+            ),
+        ),
+    )
+    chunk_repository.replace_for_document(
+        second.id,
+        (
+            NewChunk(
+                chunk_index=0,
+                text="bert text",
+                retrieval_text="bert text",
+                page_numbers=(2,),
+                headings=("Methods",),
+                warning_codes=(),
+                embedding=(0.0, 1.0),
+            ),
+        ),
+    )
+
+    results = VectorChunkRepository(db_session).search(
+        query_embedding=(1.0, 0.0),
+        document_ids=(first.id, second.id),
+        limit=2,
+    )
+
+    assert [result.document_id for result in results] == [first.id, second.id]

--- a/backend/tests/services/test_chat.py
+++ b/backend/tests/services/test_chat.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import pytest
+
+from paperchat.repositories.documents import DocumentChunkRepository, DocumentRepository, NewChunk
+from paperchat.services.chat import ChatService
+
+
+class FakeChatEmbedder:
+    def embed_documents(self, texts: Sequence[str]) -> tuple[tuple[float, ...], ...]:
+        return tuple((1.0, 0.0) for _ in texts)
+
+    def embed_query(self, text: str) -> tuple[float, ...]:
+        lowered = text.lower()
+        if "methods" in lowered:
+            return (0.0, 1.0)
+        return (1.0, 0.0)
+
+
+def create_ready_document(
+    db_session_factory,
+    *,
+    content_hash: str,
+    display_name: str,
+    embedding: tuple[float, ...],
+    retrieval_text: str,
+) -> str:
+    with db_session_factory.begin() as session:
+        document = DocumentRepository(session).create(
+            content_hash=content_hash,
+            original_filename=display_name,
+            display_name=display_name,
+            file_path=f"/tmp/{display_name}",
+            status="ready",
+        )
+        DocumentChunkRepository(session).replace_for_document(
+            document.id,
+            (
+                NewChunk(
+                    chunk_index=0,
+                    text=retrieval_text,
+                    retrieval_text=retrieval_text,
+                    page_numbers=(1,),
+                    headings=("Overview",),
+                    warning_codes=(),
+                    embedding=embedding,
+                ),
+            ),
+        )
+        return document.id
+
+
+def test_chat_service_creates_conversation_and_persists_citations(db_session_factory) -> None:
+    primary_document_id = create_ready_document(
+        db_session_factory,
+        content_hash="a" * 64,
+        display_name="attention.pdf",
+        embedding=(1.0, 0.0),
+        retrieval_text="Transformers use attention to connect distant tokens.",
+    )
+    secondary_document_id = create_ready_document(
+        db_session_factory,
+        content_hash="b" * 64,
+        display_name="bert.pdf",
+        embedding=(0.0, 1.0),
+        retrieval_text="BERT pretrains deep bidirectional language representations.",
+    )
+
+    service = ChatService(
+        session_factory=db_session_factory,
+        embedder=FakeChatEmbedder(),
+    )
+
+    result = service.send_message(prompt="How does attention work?")
+
+    assert result.conversation.title == "How does attention work?"
+    assert set(result.source_document_ids) == {primary_document_id, secondary_document_id}
+    assert result.user_message.role == "user"
+    assert result.assistant_message.role == "assistant"
+    assert len(result.assistant_message.blocks) == 3
+    assert len(result.assistant_message.citations) == 2
+    assert result.assistant_message.citations[0].document_id == primary_document_id
+
+    conversation = service.get_conversation(conversation_id=result.conversation.id)
+
+    assert conversation is not None
+    assert len(conversation.messages) == 2
+    assert conversation.messages[1].citations[0].document_id == primary_document_id
+    assert service.list_conversations()[0].message_count == 2
+
+
+def test_chat_service_appends_to_existing_conversation_and_respects_source_filter(
+    db_session_factory,
+) -> None:
+    first_document_id = create_ready_document(
+        db_session_factory,
+        content_hash="c" * 64,
+        display_name="intro.pdf",
+        embedding=(1.0, 0.0),
+        retrieval_text="The introduction explains the high-level goal.",
+    )
+    second_document_id = create_ready_document(
+        db_session_factory,
+        content_hash="d" * 64,
+        display_name="methods.pdf",
+        embedding=(0.0, 1.0),
+        retrieval_text="The methods section details the training procedure.",
+    )
+
+    service = ChatService(
+        session_factory=db_session_factory,
+        embedder=FakeChatEmbedder(),
+    )
+
+    first_turn = service.send_message(
+        prompt="Give me the intro summary.",
+        document_ids=(first_document_id,),
+    )
+    second_turn = service.send_message(
+        prompt="What are the methods?",
+        conversation_id=first_turn.conversation.id,
+        document_ids=(second_document_id,),
+    )
+
+    assert second_turn.conversation.id == first_turn.conversation.id
+    assert second_turn.source_document_ids == (second_document_id,)
+    assert second_turn.assistant_message.citations[0].document_id == second_document_id
+
+    conversation = service.get_conversation(conversation_id=first_turn.conversation.id)
+
+    assert conversation is not None
+    assert len(conversation.messages) == 4
+
+
+def test_chat_service_rejects_missing_ready_documents(db_session_factory) -> None:
+    service = ChatService(
+        session_factory=db_session_factory,
+        embedder=FakeChatEmbedder(),
+    )
+
+    with pytest.raises(ValueError, match="At least one ready document is required"):
+        service.send_message(prompt="Hello?")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,15 @@
-import { Routes, Route } from "react-router";
+import { Navigate, Route, Routes } from "react-router";
 import { BootstrapPage } from "./pages/BootstrapPage";
+import { ChatPage } from "./pages/ChatPage";
 import { MainPage } from "./pages/MainPage";
 
 export default function App() {
   return (
     <Routes>
       <Route path="/" element={<BootstrapPage />} />
-      <Route path="/app" element={<MainPage />} />
+      <Route path="/app" element={<Navigate replace to="/app/library" />} />
+      <Route path="/app/library" element={<MainPage />} />
+      <Route path="/app/chat" element={<ChatPage />} />
     </Routes>
   );
 }

--- a/frontend/src/api/chat.ts
+++ b/frontend/src/api/chat.ts
@@ -1,0 +1,87 @@
+import { fetchJson } from "./client";
+
+export type ChatRole = "user" | "assistant";
+
+export interface CitationResponse {
+  citation_id: string;
+  chunk_id: string;
+  document_id: string;
+  document_name: string;
+  page_numbers: number[];
+  headings: string[];
+  snippet: string;
+}
+
+export interface AssistantBlockResponse {
+  text: string;
+  citation_ids: string[];
+}
+
+export interface AssistantPayloadResponse {
+  blocks: AssistantBlockResponse[];
+  citations: CitationResponse[];
+}
+
+export interface ChatMessageResponse {
+  id: string;
+  role: ChatRole;
+  content: string;
+  created_at: string;
+  citations: AssistantPayloadResponse | null;
+}
+
+export interface ConversationSummaryResponse {
+  id: string;
+  title: string | null;
+  updated_at: string;
+  message_count: number;
+}
+
+export interface ConversationListResponse {
+  conversations: ConversationSummaryResponse[];
+}
+
+export interface ConversationResponse {
+  id: string;
+  title: string | null;
+  created_at: string;
+  updated_at: string;
+  messages: ChatMessageResponse[];
+}
+
+export interface ChatTurnResponse {
+  conversation: ConversationSummaryResponse;
+  user_message: ChatMessageResponse;
+  assistant_message: ChatMessageResponse;
+  source_document_ids: string[];
+}
+
+export function listConversations(): Promise<ConversationListResponse> {
+  return fetchJson<ConversationListResponse>("/api/chat/conversations");
+}
+
+export function getConversation(conversationId: string): Promise<ConversationResponse> {
+  return fetchJson<ConversationResponse>(`/api/chat/conversations/${conversationId}`);
+}
+
+export function sendMessage({
+  prompt,
+  conversationId,
+  documentIds,
+}: {
+  prompt: string;
+  conversationId?: string | null;
+  documentIds?: string[];
+}): Promise<ChatTurnResponse> {
+  return fetchJson<ChatTurnResponse>("/api/chat/messages", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      prompt,
+      conversation_id: conversationId ?? null,
+      document_ids: documentIds ?? [],
+    }),
+  });
+}

--- a/frontend/src/components/ProductNav.tsx
+++ b/frontend/src/components/ProductNav.tsx
@@ -1,0 +1,27 @@
+import { NavLink } from "react-router";
+
+export function ProductNav() {
+  return (
+    <nav className="flex flex-wrap items-center gap-1 rounded-full border border-slate-200 p-1">
+      <NavItem label="Library" to="/app/library" />
+      <NavItem label="Chat" to="/app/chat" />
+    </nav>
+  );
+}
+
+function NavItem({ label, to }: { label: string; to: string }) {
+  return (
+    <NavLink
+      className={({ isActive }) =>
+        `rounded-full px-3 py-1.5 text-sm font-medium transition ${
+          isActive
+            ? "bg-slate-950 text-white"
+            : "text-slate-600 hover:bg-slate-50 hover:text-slate-900"
+        }`
+      }
+      to={to}
+    >
+      {label}
+    </NavLink>
+  );
+}

--- a/frontend/src/pages/BootstrapPage.tsx
+++ b/frontend/src/pages/BootstrapPage.tsx
@@ -32,7 +32,7 @@ export function BootstrapPage() {
         if (cancelled) return;
 
         if (data.status === "ready") {
-          navigate("/app", { state: { version: data.app_version } });
+          navigate("/app/library", { state: { version: data.app_version } });
         } else {
           setBootstrap(data);
           if (data.errors.length > 0) {

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,0 +1,491 @@
+import { startTransition, useEffect, useState, type FormEvent } from "react";
+import {
+  getConversation,
+  listConversations,
+  sendMessage,
+  type ChatMessageResponse,
+  type ConversationResponse,
+  type ConversationSummaryResponse,
+} from "../api/chat";
+import { ApiError } from "../api/client";
+import { listDocuments, type DocumentResponse } from "../api/documents";
+import { ProductNav } from "../components/ProductNav";
+
+type NoticeTone = "success" | "warning" | "error";
+
+interface Notice {
+  tone: NoticeTone;
+  message: string;
+}
+
+export function ChatPage() {
+  const [documents, setDocuments] = useState<DocumentResponse[]>([]);
+  const [conversations, setConversations] = useState<ConversationSummaryResponse[]>([]);
+  const [activeConversation, setActiveConversation] = useState<ConversationResponse | null>(null);
+  const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
+  const [expandedAssistantMessageId, setExpandedAssistantMessageId] = useState<string | null>(null);
+  const [selectedDocumentIds, setSelectedDocumentIds] = useState<string[]>([]);
+  const [prompt, setPrompt] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [notice, setNotice] = useState<Notice | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      setLoading(true);
+      try {
+        const [documentData, conversationData] = await Promise.all([
+          listDocuments(),
+          listConversations(),
+        ]);
+
+        startTransition(() => {
+          setDocuments(documentData.documents);
+          setConversations(conversationData.conversations);
+        });
+
+        const nextConversationId = conversationData.conversations[0]?.id ?? null;
+        if (nextConversationId) {
+          await loadConversation(nextConversationId);
+        } else {
+          startTransition(() => {
+            setActiveConversation(null);
+            setActiveConversationId(null);
+            setExpandedAssistantMessageId(null);
+          });
+        }
+      } catch (error) {
+        setNotice({
+          tone: "error",
+          message: toErrorMessage(error),
+        });
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    const readyIds = documents
+      .filter((document) => document.status === "ready")
+      .map((document) => document.id);
+    if (readyIds.length === 0) {
+      setSelectedDocumentIds([]);
+      return;
+    }
+
+    setSelectedDocumentIds((currentIds) => {
+      const nextIds = currentIds.filter((documentId) => readyIds.includes(documentId));
+      if (nextIds.length > 0) {
+        return nextIds;
+      }
+      return readyIds;
+    });
+  }, [documents]);
+
+  async function loadConversation(conversationId: string) {
+    const data = await getConversation(conversationId);
+    startTransition(() => {
+      setActiveConversation(data);
+      setActiveConversationId(data.id);
+      setExpandedAssistantMessageId(latestAssistantMessage(data.messages)?.id ?? null);
+      setSidebarOpen(false);
+    });
+  }
+
+  async function refreshConversations() {
+    const data = await listConversations();
+    startTransition(() => {
+      setConversations(data.conversations);
+    });
+  }
+
+  async function handleSendMessage(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmedPrompt = prompt.trim();
+    if (!trimmedPrompt) {
+      return;
+    }
+
+    setSending(true);
+    setNotice(null);
+
+    try {
+      const result = await sendMessage({
+        prompt: trimmedPrompt,
+        conversationId: activeConversationId,
+        documentIds: selectedDocumentIds,
+      });
+      await Promise.all([refreshConversations(), loadConversation(result.conversation.id)]);
+      setPrompt("");
+      setNotice({
+        tone: "success",
+        message:
+          result.source_document_ids.length === readyDocuments.length
+            ? "Grounded against all ready documents."
+            : `Grounded against ${result.source_document_ids.length} selected document${result.source_document_ids.length === 1 ? "" : "s"}.`,
+      });
+    } catch (error) {
+      setNotice({
+        tone: "error",
+        message: toErrorMessage(error),
+      });
+    } finally {
+      setSending(false);
+    }
+  }
+
+  function startNewConversation() {
+    setActiveConversation(null);
+    setActiveConversationId(null);
+    setExpandedAssistantMessageId(null);
+    setPrompt("");
+    setNotice(null);
+    setSidebarOpen(false);
+  }
+
+  function toggleDocument(documentId: string) {
+    setSelectedDocumentIds((currentIds) => {
+      if (currentIds.includes(documentId)) {
+        const nextIds = currentIds.filter((id) => id !== documentId);
+        return nextIds.length === 0 ? currentIds : nextIds;
+      }
+      return [...currentIds, documentId];
+    });
+  }
+
+  const readyDocuments = documents.filter((document) => document.status === "ready");
+  const selectedReadyDocuments = readyDocuments.filter((document) =>
+    selectedDocumentIds.includes(document.id),
+  );
+
+  return (
+    <div className="min-h-screen bg-white text-slate-900">
+      <div className="mx-auto flex min-h-screen max-w-6xl flex-col px-4 py-4 lg:px-6">
+        <header className="flex items-center justify-between gap-4 border-b border-slate-200 pb-4">
+          <div className="flex min-w-0 items-center gap-4">
+            <div>
+              <h1
+                className="text-2xl font-semibold tracking-tight text-slate-950"
+                style={{ fontFamily: '"Iowan Old Style", "Palatino Linotype", Georgia, serif' }}
+              >
+                PaperChat
+              </h1>
+              <p className="text-sm text-slate-500">Grounded chat over your local papers.</p>
+            </div>
+            <div className="hidden md:block">
+              <ProductNav />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              className="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 lg:hidden"
+              onClick={() => {
+                setSidebarOpen((current) => !current);
+              }}
+              type="button"
+            >
+              {sidebarOpen ? "Close" : "Sidebar"}
+            </button>
+            <button
+              className="rounded-full bg-slate-950 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800"
+              onClick={startNewConversation}
+              type="button"
+            >
+              New chat
+            </button>
+          </div>
+        </header>
+
+        <div className="mt-3 md:hidden">
+          <ProductNav />
+        </div>
+
+        {notice && <NoticeBanner notice={notice} />}
+
+        <div className="mt-5 grid flex-1 gap-6 lg:grid-cols-[15rem_minmax(0,1fr)]">
+          <aside
+            className={`${sidebarOpen ? "block" : "hidden"} border-b border-slate-200 pb-4 lg:block lg:border-b-0 lg:border-r lg:pb-0 lg:pr-6`}
+          >
+            <section>
+              <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                Conversations
+              </h2>
+              <div className="mt-3 space-y-1.5">
+                {conversations.length === 0 ? (
+                  <p className="text-sm text-slate-500">No conversations yet.</p>
+                ) : (
+                  conversations.map((conversation) => (
+                    <button
+                      className={`w-full rounded-xl px-3 py-2 text-left text-sm transition ${
+                        activeConversationId === conversation.id
+                          ? "bg-slate-100 font-medium text-slate-950"
+                          : "text-slate-600 hover:bg-slate-50 hover:text-slate-900"
+                      }`}
+                      key={conversation.id}
+                      onClick={() => {
+                        void loadConversation(conversation.id);
+                      }}
+                      type="button"
+                    >
+                      <p className="truncate">{conversation.title ?? "Untitled conversation"}</p>
+                      <p className="mt-1 text-xs text-slate-400">
+                        {conversation.message_count} messages
+                      </p>
+                    </button>
+                  ))
+                )}
+              </div>
+            </section>
+
+            <section className="mt-6">
+              <h2 className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                Documents
+              </h2>
+              <p className="mt-2 text-sm text-slate-500">Choose which ready papers to search.</p>
+              <div className="mt-3 space-y-2">
+                {readyDocuments.length === 0 ? (
+                  <p className="text-sm text-slate-500">
+                    Add and finish ingesting a paper in the library first.
+                  </p>
+                ) : (
+                  readyDocuments.map((document) => (
+                    <label
+                      className="flex items-start gap-3 rounded-xl px-2 py-2 text-sm text-slate-700 hover:bg-slate-50"
+                      key={document.id}
+                    >
+                      <input
+                        checked={selectedDocumentIds.includes(document.id)}
+                        className="mt-1"
+                        onChange={() => {
+                          toggleDocument(document.id);
+                        }}
+                        type="checkbox"
+                      />
+                      <span className="min-w-0">
+                        <span className="block truncate font-medium text-slate-900">
+                          {document.display_name}
+                        </span>
+                        <span className="block text-xs text-slate-400">
+                          {document.chunk_count} chunks
+                        </span>
+                      </span>
+                    </label>
+                  ))
+                )}
+              </div>
+            </section>
+          </aside>
+
+          <main className="flex min-h-[72vh] flex-col">
+            <div className="border-b border-slate-200 pb-4">
+              <p className="text-base font-medium text-slate-950">
+                {activeConversation?.title ?? "New chat"}
+              </p>
+              <p className="mt-1 text-sm text-slate-500">
+                Ask a grounded question about your selected papers.
+              </p>
+            </div>
+
+            <div className="flex-1 space-y-6 overflow-y-auto py-6">
+              {loading ? (
+                <div className="flex h-full min-h-64 items-center justify-center">
+                  <p className="text-sm text-slate-400">Loading chat...</p>
+                </div>
+              ) : (activeConversation?.messages ?? []).length === 0 ? (
+                <EmptyState />
+              ) : (
+                (activeConversation?.messages ?? []).map((message) => {
+                  const isExpanded = expandedAssistantMessageId === message.id;
+                  return (
+                    <article className="space-y-3" key={message.id}>
+                      <div
+                        className={`max-w-3xl ${
+                          message.role === "user" ? "ml-auto" : ""
+                        }`}
+                      >
+                        <div className="mb-2 flex items-center gap-3 text-xs text-slate-400">
+                          <span className="font-medium uppercase tracking-[0.18em]">
+                            {message.role === "user" ? "You" : "Assistant"}
+                          </span>
+                          <span>{formatDateTime(message.created_at)}</span>
+                        </div>
+
+                        {message.role === "assistant" && message.citations ? (
+                          <div className="space-y-3">
+                            {message.citations.blocks.map((block, index) => (
+                              <div
+                                className="rounded-2xl bg-slate-50 px-4 py-3 text-sm leading-7 text-slate-700"
+                                key={`${message.id}-${index}`}
+                              >
+                                {block.text}
+                              </div>
+                            ))}
+
+                            <button
+                              className="text-sm font-medium text-slate-500 transition hover:text-slate-900"
+                              onClick={() => {
+                                setExpandedAssistantMessageId(isExpanded ? null : message.id);
+                              }}
+                              type="button"
+                            >
+                              {isExpanded
+                                ? "Hide sources"
+                                : `Show sources (${message.citations.citations.length})`}
+                            </button>
+
+                            {isExpanded && (
+                              <div className="space-y-4 border-l border-slate-200 pl-4">
+                                {message.citations.citations.map((citation) => (
+                                  <article key={citation.citation_id}>
+                                    <div className="flex flex-wrap items-center gap-2 text-sm">
+                                      <span className="font-medium text-slate-900">
+                                        {citation.document_name}
+                                      </span>
+                                      <span className="text-xs text-slate-400">
+                                        {formatPages(citation.page_numbers)}
+                                      </span>
+                                    </div>
+                                    {citation.headings.length > 0 && (
+                                      <p className="mt-1 text-xs text-slate-500">
+                                        {citation.headings.join(" / ")}
+                                      </p>
+                                    )}
+                                    <p className="mt-2 text-sm leading-6 text-slate-600">
+                                      {citation.snippet}
+                                    </p>
+                                  </article>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                        ) : (
+                          <div className="rounded-2xl bg-slate-900 px-4 py-3 text-sm leading-7 text-white">
+                            {message.content}
+                          </div>
+                        )}
+                      </div>
+                    </article>
+                  );
+                })
+              )}
+            </div>
+
+            <form className="border-t border-slate-200 pt-4" onSubmit={handleSendMessage}>
+              {selectedReadyDocuments.length > 0 && (
+                <div className="mb-3 flex flex-wrap gap-2">
+                  {selectedReadyDocuments.map((document) => (
+                    <span
+                      className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600"
+                      key={document.id}
+                    >
+                      {document.display_name}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              <label className="block">
+                <span className="sr-only">Ask a grounded question</span>
+                <textarea
+                  className="min-h-28 w-full rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-slate-400"
+                  onChange={(event) => {
+                    setPrompt(event.target.value);
+                  }}
+                  placeholder="Ask a question about your selected papers..."
+                  value={prompt}
+                />
+              </label>
+
+              <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-sm text-slate-500">
+                  Searching {selectedDocumentIds.length || readyDocuments.length} ready document
+                  {selectedDocumentIds.length === 1 ? "" : "s"}.
+                </p>
+                <button
+                  className="inline-flex items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-sm font-medium text-white transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:bg-slate-300"
+                  disabled={sending || readyDocuments.length === 0 || prompt.trim().length === 0}
+                  type="submit"
+                >
+                  {sending ? "Searching..." : "Send"}
+                </button>
+              </div>
+            </form>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function NoticeBanner({ notice }: { notice: Notice }) {
+  const palette =
+    notice.tone === "success"
+      ? "border-emerald-200 bg-emerald-50 text-emerald-900"
+      : notice.tone === "warning"
+        ? "border-amber-200 bg-amber-50 text-amber-900"
+        : "border-rose-200 bg-rose-50 text-rose-800";
+
+  return (
+    <div className={`mt-4 rounded-2xl border px-4 py-3 text-sm ${palette}`}>
+      {notice.message}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex min-h-64 items-center justify-center">
+      <div className="max-w-md text-center">
+        <p className="text-base font-medium text-slate-950">Ready for your first question</p>
+        <p className="mt-2 text-sm leading-6 text-slate-500">
+          Pick the papers you want to search, then send a prompt. Sources stay tucked away until you
+          ask to see them.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function latestAssistantMessage(messages: ChatMessageResponse[]): ChatMessageResponse | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    if (messages[index]?.role === "assistant") {
+      return messages[index] ?? null;
+    }
+  }
+  return null;
+}
+
+function formatPages(pageNumbers: number[]) {
+  if (pageNumbers.length === 0) {
+    return "Pages unknown";
+  }
+  if (pageNumbers.length === 1) {
+    return `Page ${pageNumbers[0]}`;
+  }
+  return `Pages ${pageNumbers.join(", ")}`;
+}
+
+function formatDateTime(value: string) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? value
+    : date.toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      });
+}
+
+function toErrorMessage(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.message;
+  }
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message;
+  }
+  return "Something went wrong while talking to the chat service.";
+}

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,11 +1,10 @@
 import {
   startTransition,
-  useCallback,
   useEffect,
   useState,
   type FormEvent,
 } from "react";
-import { useLocation } from "react-router";
+import { Link, useLocation } from "react-router";
 import { ApiError } from "../api/client";
 import {
   deleteDocument,
@@ -17,6 +16,7 @@ import {
 } from "../api/documents";
 import { pickDocuments } from "../api/localFiles";
 import { fetchRuntime, type RuntimeResponse } from "../api/runtime";
+import { ProductNav } from "../components/ProductNav";
 
 type NoticeTone = "success" | "warning" | "error";
 
@@ -39,7 +39,7 @@ export function MainPage() {
   const [addingDocuments, setAddingDocuments] = useState(false);
   const [activeDocumentId, setActiveDocumentId] = useState<string | null>(null);
 
-  const loadRuntime = useCallback(async () => {
+  async function loadRuntime() {
     try {
       const data = await fetchRuntime();
       startTransition(() => {
@@ -51,9 +51,9 @@ export function MainPage() {
         message: toErrorMessage(error),
       });
     }
-  }, []);
+  }
 
-  const loadDocuments = useCallback(async (silent = false) => {
+  async function loadDocuments(silent = false) {
     if (!silent) {
       setLoading(true);
     }
@@ -75,48 +75,45 @@ export function MainPage() {
         setLoading(false);
       }
     }
-  }, []);
+  }
 
-  const importPaths = useCallback(
-    async (paths: string[]) => {
-      if (paths.length === 0) {
-        return;
+  async function importPaths(paths: string[]) {
+    if (paths.length === 0) {
+      return;
+    }
+
+    const outcome = {
+      queued: 0,
+      duplicates: 0,
+      failedDuplicates: 0,
+    };
+
+    for (const path of paths) {
+      const result = await importDocument(path);
+      if (result.job_enqueued) {
+        outcome.queued += 1;
+        continue;
       }
 
-      const outcome = {
-        queued: 0,
-        duplicates: 0,
-        failedDuplicates: 0,
-      };
-
-      for (const path of paths) {
-        const result = await importDocument(path);
-        if (result.job_enqueued) {
-          outcome.queued += 1;
-          continue;
-        }
-
-        if (result.document.status === "failed") {
-          outcome.failedDuplicates += 1;
-        } else {
-          outcome.duplicates += 1;
-        }
+      if (result.document.status === "failed") {
+        outcome.failedDuplicates += 1;
+      } else {
+        outcome.duplicates += 1;
       }
+    }
 
-      await loadDocuments(true);
-      setNotice({
-        tone:
-          outcome.failedDuplicates > 0 || outcome.duplicates > 0 ? "warning" : "success",
-        message: summarizeImportOutcome(outcome),
-      });
-    },
-    [loadDocuments],
-  );
+    await loadDocuments(true);
+    setNotice({
+      tone:
+        outcome.failedDuplicates > 0 || outcome.duplicates > 0 ? "warning" : "success",
+      message: summarizeImportOutcome(outcome),
+    });
+  }
 
   useEffect(() => {
     void loadRuntime();
     void loadDocuments();
-  }, [loadDocuments, loadRuntime]);
+  }, []);
 
   const shouldPoll = documents.some((document) =>
     ACTIVE_STATUSES.includes(document.status),
@@ -134,7 +131,7 @@ export function MainPage() {
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [loadDocuments, shouldPoll]);
+  }, [shouldPoll]);
 
   async function handlePickDocuments() {
     setAddingDocuments(true);
@@ -244,10 +241,10 @@ export function MainPage() {
         <header className="rounded-[2rem] border border-white/70 bg-white/80 px-6 py-6 shadow-[0_24px_80px_-48px_rgba(15,23,42,0.55)] backdrop-blur">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div className="space-y-2">
-              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-teal-700">
-                Local Research Library
-              </p>
               <div className="space-y-1">
+                <p className="text-xs font-semibold uppercase tracking-[0.32em] text-teal-700">
+                  Local Research Library
+                </p>
                 <h1
                   className="text-3xl font-semibold tracking-tight text-slate-950 lg:text-4xl"
                   style={{ fontFamily: '"Iowan Old Style", "Palatino Linotype", Georgia, serif' }}
@@ -259,6 +256,7 @@ export function MainPage() {
                   chat ever starts guessing.
                 </p>
               </div>
+              <ProductNav />
             </div>
 
             <div className="grid grid-cols-3 gap-3 text-sm">
@@ -298,6 +296,15 @@ export function MainPage() {
                   {addingDocuments ? "Working..." : "Choose PDFs"}
                 </button>
               </div>
+
+              {readyCount > 0 && (
+                <Link
+                  className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-slate-50 px-5 py-3 text-sm font-medium text-slate-700 transition hover:border-teal-300 hover:text-teal-700 xl:self-start"
+                  to="/app/chat"
+                >
+                  Open grounded chat
+                </Link>
+              )}
 
               <form className="grid gap-3 md:grid-cols-[1fr_auto]" onSubmit={handleManualImport}>
                 <label className="space-y-2">

--- a/paperchat_cli/launcher.py
+++ b/paperchat_cli/launcher.py
@@ -52,7 +52,7 @@ def launch(*, no_open: bool) -> None:
         wait_for_url(f"{backend_url}/api/health", backend_process, label="backend")
 
         frontend_process = start_process(
-            [vite_command, "--host", HOST, "--port", str(FRONTEND_PORT)],
+            [vite_command, "--host", HOST, "--port", str(FRONTEND_PORT), "--strictPort"],
             cwd=paths.frontend,
             env_overrides={"VITE_API_URL": backend_url},
         )

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -113,7 +113,7 @@ def test_launch_uses_configured_backend_port_for_probe_and_frontend_api_url(
     assert process_calls == [
         (["/usr/bin/uv", "run", "paperchat-backend"], backend, None),
         (
-            ["/usr/bin/vite", "--host", "127.0.0.1", "--port", "5173"],
+            ["/usr/bin/vite", "--host", "127.0.0.1", "--port", "5173", "--strictPort"],
             frontend,
             {"VITE_API_URL": "http://127.0.0.1:9812"},
         ),


### PR DESCRIPTION
This PR turns the rebuilt PaperChat app into a real grounded-chat product by adding retrieval, conversation persistence, a first-class chat UI, and the runtime hardening needed to exercise that UI reliably in local browser runs.

## Summary

- adds the backend chat/retrieval contract on top of persisted chunks and conversations
- adds the `/app/chat` experience and promotes the product shell from library-only to library plus chat
- hardens local launch behavior so frontend port drift no longer breaks browser fetches

## Why

- PaperChat already launched, ingested PDFs, and managed a local library, but it still stopped short of the core product promise: grounded chat over user-owned papers.
- Live browser testing also exposed a real runtime paper cut in the launcher/dev-origin path that needed to be fixed before this slice could feel stable.

## Changes

- add backend chat endpoints, typed chat/citation models, deterministic grounded answer generation, and conversation persistence
- add `sqlite-vec` retrieval over persisted chunk embeddings and keep the vector index synchronized with chunk lifecycle changes
- wire the chat service into the FastAPI app and allow local dev CORS origins across `localhost` and `127.0.0.1` ports
- split the frontend shell into `/app/library` and `/app/chat`, add shared navigation, and add the chat API client
- ship a transcript-first chat UI with conversation history, source selection, inline source disclosure, and a library-to-chat entrypoint
- require the expected Vite frontend port during launcher startup and keep launcher tests aligned with that stricter contract

## Testing

- [x] `cd backend && uv run ruff check paperchat tests && uv run ruff format --check paperchat tests && uv run ty check && uv run pytest -q`
- [x] `cd frontend && pnpm lint && pnpm build`
- [x] `uv run --group dev ruff check paperchat_cli tests && uv run --group dev ruff format --check paperchat_cli tests && uv run --group dev pytest tests/test_launcher.py -q`
- [x] `uv run paperchat launch` and browser smoke the library-to-chat flow with a ready PDF